### PR TITLE
chore: Torch users schema updated

### DIFF
--- a/lib/lunchbot_web/templates/admin/user/form.html.heex
+++ b/lib/lunchbot_web/templates/admin/user/form.html.heex
@@ -22,6 +22,14 @@
         <%= error_tag f, :role %>
       </div>
     </div>
+
+    <div class="torch-form-group">
+      <%= label f, :confirmed_at %>
+      <div class="torch-form-group-input">
+        <%= text_input f, :confirmed_at %>
+        <%= error_tag f, :confirmed_at %>
+      </div>
+    </div>
   
     <div class="torch-submit-form">
       <%= submit "Submit", class: "torch-submit-button" %>

--- a/lib/lunchbot_web/templates/admin/user/index.html.heex
+++ b/lib/lunchbot_web/templates/admin/user/index.html.heex
@@ -21,8 +21,17 @@
             <%= filter_string_input(:user, :role, @conn.params) %>
           </div>
         
-        
-        
+          <div class="field">
+            <label>Hashed Password</label>
+            <%= filter_select(:user, :hashed_password, @conn.params) %>
+            <%= filter_string_input(:user, :hashed_password, @conn.params) %>
+          </div> 
+
+          <div class="field">
+            <label>Confirmed At</label>
+            <%= filter_select(:user, :confirmed_at, @conn.params) %>
+            <%= filter_string_input(:user, :confirmed_at, @conn.params) %>
+          </div> 
         
         <button type="submit" class="torch-button">Search</button>
         <%= link "Clear Filters", to: Routes.admin_user_path(@conn, :index) %>

--- a/lib/lunchbot_web/templates/admin/user/show.html.heex
+++ b/lib/lunchbot_web/templates/admin/user/show.html.heex
@@ -21,7 +21,17 @@
           <div class="torch-show-label">Role:</div>
           <div class="torch-show-data"><%= @user.role %></div>
         </div>
-      
+
+        <div class="torch-show-attribute">
+          <div class="torch-show-label">Hashed Password:</div>
+          <div class="torch-show-data"></div>
+        </div>
+
+        <div class="torch-show-attribute">
+          <div class="torch-show-label">Confirmed At:</div>
+          <div class="torch-show-data"><%= @user.confirmed_at %></div>
+        </div>
+
     </section>
   </div>
 </section>


### PR DESCRIPTION
The Torch generated schema for `:user` included `:email` and `:role` as fields, but `mix phx.gen.auth` introduced fields `:hashed_password` and `:confirmed_at`. These were updated in the Torch display and edit/new form.