### PR TITLE
feat: Defined password-set logic for Google auth

### DIFF
--- a/lib/lunchbot/accounts.ex
+++ b/lib/lunchbot/accounts.ex
@@ -189,10 +189,16 @@ defmodule Lunchbot.Accounts do
 
   """
   def update_user_password(user, password, attrs) do
+    # Our password will only be nil when setting the password after a Google login
     changeset =
-      user
-      |> User.password_changeset(attrs)
-      |> User.validate_current_password(password)
+      if(password == "") do
+        user
+        |> User.password_changeset(attrs)
+      else
+        user
+        |> User.password_changeset(attrs)
+        |> User.validate_current_password(password)
+      end
 
     Ecto.Multi.new()
     |> Ecto.Multi.update(:user, changeset)
@@ -426,7 +432,7 @@ defmodule Lunchbot.Accounts do
 
       _ ->
         %User{}
-        |> User.registration_changeset(attrs)
+        |> User.google_registration_changeset(attrs)
         |> Repo.insert()
     end
   end

--- a/lib/lunchbot/accounts/user.ex
+++ b/lib/lunchbot/accounts/user.ex
@@ -36,6 +36,12 @@ defmodule Lunchbot.Accounts.User do
     |> validate_password(opts)
   end
 
+  def google_registration_changeset(user, attrs, _opts \\ []) do
+    user
+    |> cast(attrs, [:email, :password])
+    |> validate_email()
+  end
+
   defp validate_email(changeset) do
     changeset
     |> validate_required([:email])

--- a/lib/lunchbot_web/controllers/google_auth_controller.ex
+++ b/lib/lunchbot_web/controllers/google_auth_controller.ex
@@ -3,7 +3,6 @@ defmodule LunchbotWeb.GoogleAuthController do
 
   alias Lunchbot.Accounts
   alias LunchbotWeb.UserAuth
-  @rand_pass_length 32
 
   @doc """
   `index/2` handles the callback from Google Auth API redirect.
@@ -13,7 +12,7 @@ defmodule LunchbotWeb.GoogleAuthController do
     {:ok, profile} = ElixirAuthGoogle.get_user_profile(token.access_token)
 
     if(profile.email =~ "@mojotech.com") do
-      user_params = %{email: profile.email, password: random_password()}
+      user_params = %{email: profile.email}
 
       case Accounts.fetch_or_create_user(user_params) do
         {:ok, user} ->
@@ -29,9 +28,5 @@ defmodule LunchbotWeb.GoogleAuthController do
       |> put_flash(:error, "Must log in with a MojoTech account.")
       |> redirect(to: "/")
     end
-  end
-
-  defp random_password do
-    :crypto.strong_rand_bytes(@rand_pass_length) |> Base.encode64()
   end
 end

--- a/lib/lunchbot_web/templates/user_settings/edit.html.heex
+++ b/lib/lunchbot_web/templates/user_settings/edit.html.heex
@@ -26,7 +26,7 @@
 
 <h3>Change password</h3>
 
-<.form let={f} for={@password_changeset} action={Routes.user_settings_path(@conn, :update)} id="update_password">
+<.form let={f} for={@password_changeset} action={Routes.user_settings_path(@conn, :update)} id="update_password"> 
   <%= if @password_changeset.action do %>
     <div class="alert alert-danger">
       <p>Oops, something went wrong! Please check the errors below.</p>
@@ -43,11 +43,15 @@
   <%= password_input f, :password_confirmation, required: true %>
   <%= error_tag f, :password_confirmation %>
 
-  <%= label f, :current_password, for: "current_password_for_password" %>
-  <%= password_input f, :current_password, required: true, name: "current_password", id: "current_password_for_password" %>
-  <%= error_tag f, :current_password %>
-
-  <div>
+  <%= if @current_user.hashed_password do %>
+      <%= label f, :current_password, for: "current_password_for_password" %>
+      <%= password_input f, :current_password, required: true, name: "current_password", id: "current_password_for_password" %>
+      <%= error_tag f, :current_password %> 
+  <% else %> 
+      <%= hidden_input f, :current_password, name: "current_password", id: "current_password_for_password", value: nil %> 
+  <% end %>
+  
+ <div>
     <%= submit "Change password" %>
   </div>
 </.form>


### PR DESCRIPTION
As we introduced `elixir-auth-google`, we integrated the authentication from Google with UserAuth which was generated by `mix phx.gen.auth`. Before, there was a workaround where we would create a randomized, hashed password to verify a user session after we logged in with Google. Technically, the password field is nullable, so now the user's password will simply be null after a Google authentication. From here, the user is able to set their password in the settings page like so:

<img width="500" alt="Screen Shot 2022-07-13 at 3 16 59 PM" src="https://user-images.githubusercontent.com/69921727/178837834-8fc5b235-5864-4e3a-84fd-94c538aa5f50.png">

When a user has a password, the page will look like this (now there is a current password field at the bottom):

<img width="500" alt="Screen Shot 2022-07-13 at 3 17 44 PM" src="https://user-images.githubusercontent.com/69921727/178837942-e3f376d4-3814-4e12-9ee2-90b6b91b7bf3.png">

Because of the `.heex` forms requiring the password field to login, you won't be able to log in with just the email and no password of a Google-authenticated user that has not yet set their password like so:

<img width="500" alt="Screen Shot 2022-07-13 at 3 21 04 PM" src="https://user-images.githubusercontent.com/69921727/178838475-6d8b369a-817c-4bed-a7b1-ddf7dc4280ea.png">

With this, the authentication process for Google now looks like:
- User logs in with Google
- `fetch_or_create_user` gets called from `accounts.ex` and checks if a user is already in the database. If the user is in the database, fetch that user, and otherwise, create a new user with a nil (or "") password, then log in the user with a session
- If the user wants to make a password for their Google-authenticated account, they go to the settings page and create a new password. This then calls the function `update` from `user_settings_controller.ex`, which then updates our password through `Accounts.update_user_password`. The only time that a nil value gets passed into this function would be when the user is setting up their password after a Google authentication, so we can add logic into this function to not validate `current_password` when it is nil.