### PR TITLE
feat: Connect auth to Torch + Admin verification

### DIFF
--- a/lib/lunchbot/accounts/user.ex
+++ b/lib/lunchbot/accounts/user.ex
@@ -32,7 +32,7 @@ defmodule Lunchbot.Accounts.User do
   """
   def registration_changeset(user, attrs, opts \\ []) do
     user
-    |> cast(attrs, [:email, :password])
+    |> cast(attrs, [:name, :email, :password, :role, :confirmed_at])
     |> validate_email()
     |> validate_password(opts)
   end
@@ -150,8 +150,8 @@ defmodule Lunchbot.Accounts.User do
   @doc false
   def changeset(user, attrs) do
     user
-    |> cast(attrs, [:name, :email, :role])
-    |> validate_required([:name, :email, :role])
+    |> cast(attrs, [:name, :email, :password, :role, :confirmed_at])
+    |> validate_required([:name, :email, :password, :role, :confirmed_at])
     |> unique_constraint(:email, message: "Email must be unique")
   end
 end

--- a/lib/lunchbot_web/controllers/user_auth.ex
+++ b/lib/lunchbot_web/controllers/user_auth.ex
@@ -121,6 +121,21 @@ defmodule LunchbotWeb.UserAuth do
     end
   end
 
+  def require_admin_user(conn, _opts) do
+    {user_token, conn} = ensure_user_token(conn)
+    user = user_token && Accounts.get_user_by_session_token(user_token)
+
+    if user != nil and user.role == "admin" do
+      conn
+    else
+      conn
+      |> put_flash(:error, "You must be an admin to access this page.")
+      |> maybe_store_return_to()
+      |> redirect(to: Routes.user_session_path(conn, :new))
+      |> halt()
+    end
+  end
+
   @doc """
   Used for routes that require the user to be authenticated.
 

--- a/lib/lunchbot_web/router.ex
+++ b/lib/lunchbot_web/router.ex
@@ -18,7 +18,7 @@ defmodule LunchbotWeb.Router do
   end
 
   scope "/admin", LunchbotWeb.Admin, as: :admin do
-    pipe_through :browser
+    pipe_through [:browser, :require_admin_user]
 
     resources "/users", UserController
     resources "/offices", OfficeController

--- a/lib/lunchbot_web/templates/layout/torch.html.heex
+++ b/lib/lunchbot_web/templates/layout/torch.html.heex
@@ -15,8 +15,8 @@
     <header>
       <section id="torch-account-info">
         <div class="torch-container">
-          <a href="/">user@example.com</a>
-          <a href="/">Logout</a>
+          <a href="/"><%= @current_user.email %></a>
+          <a><%= link "Log out", to: Routes.user_session_path(@conn, :delete), method: :delete %></a>
         </div>
       </section>
 

--- a/lib/lunchbot_web/templates/page/index.html.heex
+++ b/lib/lunchbot_web/templates/page/index.html.heex
@@ -3,6 +3,17 @@
   <p>Peace of mind from prototype to production</p>
   <%= if assigns[:current_user] do %>
     <h2> Logged in as <%= @current_user.email %> </h2>
+    <%= if @current_user.role == "admin" do %>
+      <font size="+3">
+        <center>
+            <strong>
+            <li>
+                <a href="/admin/users">Torch</a>
+            </li>
+            </strong>
+        </center>
+      </font>
+    <% end %>
   <% else %>
     <p>To get started, login to your Google Account or login at the top of the page: </p>
     <a href={@oauth_google_url}>

--- a/test/lunchbot/lunchbot_data_test.exs
+++ b/test/lunchbot/lunchbot_data_test.exs
@@ -87,7 +87,7 @@ defmodule Lunchbot.LunchbotDataTest do
     end
 
     test "with invalid data returns error changeset" do
-      user = user_fixture()
+      user = Map.replace!(user_fixture(), :password, nil)
       assert {:error, %Ecto.Changeset{}} = Accounts.update_user(user, @invalid_attrs)
       assert user == Accounts.get_user!(user.id)
     end

--- a/test/lunchbot_web/controllers/admin/category_controller_test.exs
+++ b/test/lunchbot_web/controllers/admin/category_controller_test.exs
@@ -12,6 +12,10 @@ defmodule LunchbotWeb.Admin.CategoryControllerTest do
     category
   end
 
+  setup do
+    initialize_admin_user()
+  end
+
   describe "index" do
     test "lists all categories", %{conn: conn} do
       conn = get(conn, Routes.admin_category_path(conn, :index))

--- a/test/lunchbot_web/controllers/admin/extra_controller_test.exs
+++ b/test/lunchbot_web/controllers/admin/extra_controller_test.exs
@@ -12,6 +12,10 @@ defmodule LunchbotWeb.Admin.ExtraControllerTest do
     extra
   end
 
+  setup do
+    initialize_admin_user()
+  end
+
   describe "index" do
     test "lists all extras", %{conn: conn} do
       conn = get(conn, Routes.admin_extra_path(conn, :index))

--- a/test/lunchbot_web/controllers/admin/item_controller_test.exs
+++ b/test/lunchbot_web/controllers/admin/item_controller_test.exs
@@ -17,6 +17,10 @@ defmodule LunchbotWeb.Admin.ItemControllerTest do
     item
   end
 
+  setup do
+    initialize_admin_user()
+  end
+
   describe "index" do
     test "lists all items", %{conn: conn} do
       conn = get(conn, Routes.admin_item_path(conn, :index))

--- a/test/lunchbot_web/controllers/admin/item_extra_controller_test.exs
+++ b/test/lunchbot_web/controllers/admin/item_extra_controller_test.exs
@@ -12,6 +12,10 @@ defmodule LunchbotWeb.Admin.ItemExtraControllerTest do
     item_extra
   end
 
+  setup do
+    initialize_admin_user()
+  end
+
   describe "index" do
     test "lists all item_extras", %{conn: conn} do
       conn = get(conn, Routes.admin_item_extra_path(conn, :index))

--- a/test/lunchbot_web/controllers/admin/menu_controller_test.exs
+++ b/test/lunchbot_web/controllers/admin/menu_controller_test.exs
@@ -12,6 +12,10 @@ defmodule LunchbotWeb.Admin.MenuControllerTest do
     menu
   end
 
+  setup do
+    initialize_admin_user()
+  end
+
   describe "index" do
     test "lists all menus", %{conn: conn} do
       conn = get(conn, Routes.admin_menu_path(conn, :index))

--- a/test/lunchbot_web/controllers/admin/office_controller_test.exs
+++ b/test/lunchbot_web/controllers/admin/office_controller_test.exs
@@ -12,6 +12,10 @@ defmodule LunchbotWeb.Admin.OfficeControllerTest do
     office
   end
 
+  setup do
+    initialize_admin_user()
+  end
+
   describe "index" do
     test "lists all offices", %{conn: conn} do
       conn = get(conn, Routes.admin_office_path(conn, :index))

--- a/test/lunchbot_web/controllers/admin/office_lunch_order_controller_test.exs
+++ b/test/lunchbot_web/controllers/admin/office_lunch_order_controller_test.exs
@@ -12,6 +12,10 @@ defmodule LunchbotWeb.Admin.OfficeLunchOrderControllerTest do
     office_lunch_order
   end
 
+  setup do
+    initialize_admin_user()
+  end
+
   describe "index" do
     test "lists all office_lunch_orders", %{conn: conn} do
       conn = get(conn, Routes.admin_office_lunch_order_path(conn, :index))

--- a/test/lunchbot_web/controllers/admin/order_controller_test.exs
+++ b/test/lunchbot_web/controllers/admin/order_controller_test.exs
@@ -12,6 +12,10 @@ defmodule LunchbotWeb.Admin.OrderControllerTest do
     order
   end
 
+  setup do
+    initialize_admin_user()
+  end
+
   describe "index" do
     test "lists all orders", %{conn: conn} do
       conn = get(conn, Routes.admin_order_path(conn, :index))

--- a/test/lunchbot_web/controllers/admin/order_item_controller_test.exs
+++ b/test/lunchbot_web/controllers/admin/order_item_controller_test.exs
@@ -12,6 +12,10 @@ defmodule LunchbotWeb.Admin.OrderItemControllerTest do
     order_item
   end
 
+  setup do
+    initialize_admin_user()
+  end
+
   describe "index" do
     test "lists all order_items", %{conn: conn} do
       conn = get(conn, Routes.admin_order_item_path(conn, :index))

--- a/test/lunchbot_web/controllers/admin/order_item_extra_controller_test.exs
+++ b/test/lunchbot_web/controllers/admin/order_item_extra_controller_test.exs
@@ -12,6 +12,10 @@ defmodule LunchbotWeb.Admin.OrderItemExtraControllerTest do
     order_item_extra
   end
 
+  setup do
+    initialize_admin_user()
+  end
+
   describe "index" do
     test "lists all order_item_extras", %{conn: conn} do
       conn = get(conn, Routes.admin_order_item_extra_path(conn, :index))

--- a/test/lunchbot_web/controllers/admin/user_controller_test.exs
+++ b/test/lunchbot_web/controllers/admin/user_controller_test.exs
@@ -99,10 +99,8 @@ defmodule LunchbotWeb.Admin.UserControllerTest do
     test "deletes chosen user", %{conn: conn, user: user} do
       conn = delete(conn, Routes.admin_user_path(conn, :delete, user))
       assert redirected_to(conn) == Routes.admin_user_path(conn, :index)
-
-      assert_error_sent 404, fn ->
-        get(conn, Routes.admin_user_path(conn, :show, user))
-      end
+      conn = get(conn, Routes.admin_user_path(conn, :show, user))
+      assert html_response(conn, 302) =~ "/users/log_in"
     end
   end
 end

--- a/test/support/fixtures/lunchbot_data_fixtures.ex
+++ b/test/support/fixtures/lunchbot_data_fixtures.ex
@@ -12,10 +12,12 @@ defmodule Lunchbot.LunchbotDataFixtures do
       attrs
       |> Enum.into(%{
         name: "some name",
-        email: "some email",
-        role: "some role"
+        email: "some_email@mojotech.com",
+        password: "some_password",
+        role: "admin",
+        confirmed_at: ~N[2001-01-01 23:00:07]
       })
-      |> Lunchbot.LunchbotData.create_user()
+      |> Lunchbot.Accounts.create_user()
 
     user
   end


### PR DESCRIPTION
We now have admin verification for accessing Torch. When we update the database like so with `role = 'admin'`:

<img width="371" alt="Screen Shot 2022-07-14 at 10 48 50 AM" src="https://user-images.githubusercontent.com/69921727/179124525-0ec1b0ce-e873-476e-bac8-44a736afac48.png">

We then have a new front page that gives us access to Torch:

<img width="360" alt="Screen Shot 2022-07-14 at 10 48 58 AM" src="https://user-images.githubusercontent.com/69921727/179124565-5d5f9c2c-5245-4434-9d72-53b909f51cea.png">

If we try to access the route `/admin/users` from any other account, we get the following flash:

<img width="569" alt="Screen Shot 2022-07-14 at 10 52 56 AM" src="https://user-images.githubusercontent.com/69921727/179124605-4652a7e0-2b9f-4292-8ad9-bae8bc830836.png">

We also now have a correct email and logout functionality from the Torch display, shown here:

<img width="400" alt="Screen Shot 2022-07-14 at 6 51 53 PM" src="https://user-images.githubusercontent.com/69921727/179125034-9d9b79b9-ad77-4855-bfd5-4dc46c818ea6.png">

A lot of tests were changed in the first commit due to the routes of `/admin` now requiring the user's role in the database to be `admin`, so in order to keep the functionality of those tests we had to initialize a user session by having the code:

```
setup do
  initialize_admin_user()
end
```

In `user_controller_test.exs`, the logic is slightly different but the concept is the same.

