### PR TITLE
chore: seeding PVD menu data

### DIFF
--- a/lib/lunchbot/lunchbot_data.ex
+++ b/lib/lunchbot/lunchbot_data.ex
@@ -1705,6 +1705,9 @@ defmodule Lunchbot.LunchbotData do
   defp filter_config(:items) do
     defconfig do
       text(:name)
+      text(:description)
+      number(:price)
+      text(:item_image)
       number(:category_id)
       text(:image_url)
       boolean(:deleted)

--- a/lib/lunchbot/lunchbot_data/category.ex
+++ b/lib/lunchbot/lunchbot_data/category.ex
@@ -3,7 +3,6 @@ defmodule Lunchbot.LunchbotData.Category do
   import Ecto.Changeset
 
   schema "categories" do
-    field :menu_id, :integer
     field :name, :string
 
     timestamps()
@@ -12,7 +11,7 @@ defmodule Lunchbot.LunchbotData.Category do
   @doc false
   def changeset(category, attrs) do
     category
-    |> cast(attrs, [:name, :menu_id])
-    |> validate_required([:name, :menu_id])
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
   end
 end

--- a/lib/lunchbot/lunchbot_data/item.ex
+++ b/lib/lunchbot/lunchbot_data/item.ex
@@ -5,8 +5,11 @@ defmodule Lunchbot.LunchbotData.Item do
   schema "items" do
     field :category_id, :integer
     field :deleted, :boolean, default: false
+    field :description, :string
     field :image_url, :string
+    field :item_image, :string
     field :name, :string
+    field :price, :integer
 
     timestamps()
   end
@@ -14,7 +17,7 @@ defmodule Lunchbot.LunchbotData.Item do
   @doc false
   def changeset(item, attrs) do
     item
-    |> cast(attrs, [:name, :category_id, :image_url, :deleted])
-    |> validate_required([:name, :category_id, :image_url, :deleted])
+    |> cast(attrs, [:name, :description, :price, :category_id, :image_url, :item_image, :deleted])
+    |> validate_required([:name, :price, :category_id])
   end
 end

--- a/lib/lunchbot/lunchbot_data/menu_categories.ex
+++ b/lib/lunchbot/lunchbot_data/menu_categories.ex
@@ -1,0 +1,18 @@
+defmodule Lunchbot.LunchbotData.MenuCategories do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "menu_categories" do
+    field :category_id, :integer
+    field :menu_id, :integer
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(menu_categories, attrs) do
+    menu_categories
+    |> cast(attrs, [:category_id, :menu_id])
+    |> validate_required([:category_id, :menu_id])
+  end
+end

--- a/lib/lunchbot_web/controllers/admin/menu_categories_controller.ex
+++ b/lib/lunchbot_web/controllers/admin/menu_categories_controller.ex
@@ -1,0 +1,72 @@
+defmodule LunchbotWeb.Admin.MenuCategoriesController do
+  use LunchbotWeb, :controller
+
+  alias Lunchbot.LunchbotData
+  alias Lunchbot.LunchbotData.MenuCategories
+
+  plug(:put_root_layout, {LunchbotWeb.LayoutView, "torch.html"})
+  plug(:put_layout, false)
+
+  def index(conn, params) do
+    case LunchbotData.paginate_menu_categories(params) do
+      {:ok, assigns} ->
+        render(conn, "index.html", assigns)
+
+      error ->
+        conn
+        |> put_flash(:error, "There was an error rendering Menu categories. #{inspect(error)}")
+        |> redirect(to: Routes.admin_menu_categories_path(conn, :index))
+    end
+  end
+
+  def new(conn, _params) do
+    changeset = LunchbotData.change_menu_categories(%MenuCategories{})
+    render(conn, "new.html", changeset: changeset)
+  end
+
+  def create(conn, %{"menu_categories" => menu_categories_params}) do
+    case LunchbotData.create_menu_categories(menu_categories_params) do
+      {:ok, menu_categories} ->
+        conn
+        |> put_flash(:info, "Menu categories created successfully.")
+        |> redirect(to: Routes.admin_menu_categories_path(conn, :show, menu_categories))
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "new.html", changeset: changeset)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    menu_categories = LunchbotData.get_menu_categories!(id)
+    render(conn, "show.html", menu_categories: menu_categories)
+  end
+
+  def edit(conn, %{"id" => id}) do
+    menu_categories = LunchbotData.get_menu_categories!(id)
+    changeset = LunchbotData.change_menu_categories(menu_categories)
+    render(conn, "edit.html", menu_categories: menu_categories, changeset: changeset)
+  end
+
+  def update(conn, %{"id" => id, "menu_categories" => menu_categories_params}) do
+    menu_categories = LunchbotData.get_menu_categories!(id)
+
+    case LunchbotData.update_menu_categories(menu_categories, menu_categories_params) do
+      {:ok, menu_categories} ->
+        conn
+        |> put_flash(:info, "Menu categories updated successfully.")
+        |> redirect(to: Routes.admin_menu_categories_path(conn, :show, menu_categories))
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "edit.html", menu_categories: menu_categories, changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    menu_categories = LunchbotData.get_menu_categories!(id)
+    {:ok, _menu_categories} = LunchbotData.delete_menu_categories(menu_categories)
+
+    conn
+    |> put_flash(:info, "Menu categories deleted successfully.")
+    |> redirect(to: Routes.admin_menu_categories_path(conn, :index))
+  end
+end

--- a/lib/lunchbot_web/router.ex
+++ b/lib/lunchbot_web/router.ex
@@ -32,6 +32,7 @@ defmodule LunchbotWeb.Router do
     resources "/option_headings", OptionHeadingsController
     resources "/order_item_options", OrderItemOptionsController
     resources "/options", OptionsController
+    resources "/menu_categories", MenuCategoriesController
   end
 
   scope "/", LunchbotWeb do

--- a/lib/lunchbot_web/templates/admin/category/index.html.heex
+++ b/lib/lunchbot_web/templates/admin/category/index.html.heex
@@ -15,15 +15,6 @@
             <%= filter_string_input(:category, :name, @conn.params) %>
           </div>
         
-        
-        
-        
-          <div class="field">
-            <label>Menu</label>
-            <%= number_filter_select(:category, :menu_id, @conn.params) %>
-            <%= filter_number_input(:category, :menu_id, @conn.params) %>
-          </div>
-        
         <button type="submit" class="torch-button">Search</button>
         <%= link "Clear Filters", to: Routes.admin_category_path(@conn, :index) %>
       <% end %>
@@ -38,8 +29,6 @@
             
               <th><%= table_link(@conn, "Name", :name) %></th>
             
-              <th><%= table_link(@conn, "Menu", :menu_id) %></th>
-            
             <th><span>Actions</span></th>
           </tr>
         </thead>
@@ -48,8 +37,6 @@
             <tr>
               
                 <td><%= category.name %></td>
-              
-                <td><%= category.menu_id %></td>
               
               <td class="torch-actions">
                 <span><%= link "Show", to: Routes.admin_category_path(@conn, :show, category) %></span>

--- a/lib/lunchbot_web/templates/admin/category/show.html.heex
+++ b/lib/lunchbot_web/templates/admin/category/show.html.heex
@@ -17,11 +17,6 @@
           <div class="torch-show-data"><%= @category.name %></div>
         </div>
       
-        <div class="torch-show-attribute">
-          <div class="torch-show-label">Menu:</div>
-          <div class="torch-show-data"><%= @category.menu_id %></div>
-        </div>
-      
     </section>
   </div>
 </section>

--- a/lib/lunchbot_web/templates/admin/item/form.html.heex
+++ b/lib/lunchbot_web/templates/admin/item/form.html.heex
@@ -14,6 +14,22 @@
         <%= error_tag f, :name %>
       </div>
     </div>
+
+    <div class="torch-form-group">
+      <%= label f, :description %>
+      <div class="torch-form-group-input">
+        <%= text_input f, :description %>
+        <%= error_tag f, :description %>
+      </div>
+    </div>
+
+    <div class="torch-form-group">
+      <%= label f, :price %>
+      <div class="torch-form-group-input">
+        <%= number_input f, :price %>
+        <%= error_tag f, :price %>
+      </div>
+    </div>
   
     <div class="torch-form-group">
       <%= label f, :category_id %>

--- a/lib/lunchbot_web/templates/admin/item/index.html.heex
+++ b/lib/lunchbot_web/templates/admin/item/index.html.heex
@@ -14,6 +14,18 @@
             <%= filter_select(:item, :name, @conn.params) %>
             <%= filter_string_input(:item, :name, @conn.params) %>
           </div>
+
+          <div class="field">
+            <label>Description</label>
+            <%= filter_select(:item, :description, @conn.params) %>
+            <%= filter_string_input(:item, :description, @conn.params) %>
+          </div>
+
+          <div class="field">
+            <label>Price</label>
+            <%= filter_select(:item, :price, @conn.params) %>
+            <%= filter_string_input(:item, :price, @conn.params) %>
+          </div>
         
           <div class="field">
             <label>Image url</label>
@@ -48,6 +60,10 @@
           <tr>
             
               <th><%= table_link(@conn, "Name", :name) %></th>
+
+              <th><%= table_link(@conn, "Description", :description) %></th>
+
+              <th><%= table_link(@conn, "Price", :price) %></th>
             
               <th><%= table_link(@conn, "Category", :category_id) %></th>
             
@@ -63,6 +79,10 @@
             <tr>
               
                 <td><%= item.name %></td>
+
+                <td><%= item.description %></td>
+
+                <td><%= item.price %></td>
               
                 <td><%= item.category_id %></td>
               

--- a/lib/lunchbot_web/templates/admin/item/show.html.heex
+++ b/lib/lunchbot_web/templates/admin/item/show.html.heex
@@ -16,6 +16,16 @@
           <div class="torch-show-label">Name:</div>
           <div class="torch-show-data"><%= @item.name %></div>
         </div>
+
+        <div class="torch-show-attribute">
+          <div class="torch-show-label">Description:</div>
+          <div class="torch-show-data"><%= @item.description %></div>
+        </div>
+
+        <div class="torch-show-attribute">
+          <div class="torch-show-label">Price:</div>
+          <div class="torch-show-data"><%= @item.price %></div>
+        </div>
       
         <div class="torch-show-attribute">
           <div class="torch-show-label">Category:</div>

--- a/lib/lunchbot_web/templates/admin/menu_categories/edit.html.heex
+++ b/lib/lunchbot_web/templates/admin/menu_categories/edit.html.heex
@@ -1,0 +1,14 @@
+<section id="torch-toolbar">
+  <div class="torch-container">
+    <%= link "Cancel", to: Routes.admin_menu_categories_path(@conn, :index), class: "torch-button" %>
+  </div>
+</section>
+
+<section id="torch-header-and-content">
+  <div class="torch-container">
+    <div class="header">
+      <h3>Edit Menu categories</h3>
+    </div>
+    <%= render "form.html", Map.put(assigns, :action, Routes.admin_menu_categories_path(@conn, :update, @menu_categories)) %>
+  </div>
+</section>

--- a/lib/lunchbot_web/templates/admin/menu_categories/form.html.heex
+++ b/lib/lunchbot_web/templates/admin/menu_categories/form.html.heex
@@ -8,10 +8,18 @@
     <% end %>
   
     <div class="torch-form-group">
-      <%= label f, :name %>
+      <%= label f, :category_id %>
       <div class="torch-form-group-input">
-        <%= text_input f, :name %>
-        <%= error_tag f, :name %>
+        <%= number_input f, :category_id %>
+        <%= error_tag f, :category_id %>
+      </div>
+    </div>
+  
+    <div class="torch-form-group">
+      <%= label f, :menu_id %>
+      <div class="torch-form-group-input">
+        <%= number_input f, :menu_id %>
+        <%= error_tag f, :menu_id %>
       </div>
     </div>
   

--- a/lib/lunchbot_web/templates/admin/menu_categories/index.html.heex
+++ b/lib/lunchbot_web/templates/admin/menu_categories/index.html.heex
@@ -1,0 +1,69 @@
+<section id="torch-toolbar">
+  <div class="torch-container">
+    <%= link "New Menu categories", to: Routes.admin_menu_categories_path(@conn, :new) %>
+  </div>
+</section>
+<section id="torch-index-content">
+  <div class="torch-container">
+    <section id="torch-filters">
+      <h3>Find Menu categories</h3>
+      <%= form_tag @conn.request_path, method: :get, id: "torch-filters-form" do %>
+        
+        
+        
+        
+          <div class="field">
+            <label>Category</label>
+            <%= number_filter_select(:menu_categories, :category_id, @conn.params) %>
+            <%= filter_number_input(:menu_categories, :category_id, @conn.params) %>
+          </div>
+        
+          <div class="field">
+            <label>Menu</label>
+            <%= number_filter_select(:menu_categories, :menu_id, @conn.params) %>
+            <%= filter_number_input(:menu_categories, :menu_id, @conn.params) %>
+          </div>
+        
+        <button type="submit" class="torch-button">Search</button>
+        <%= link "Clear Filters", to: Routes.admin_menu_categories_path(@conn, :index) %>
+      <% end %>
+
+    </section>
+
+    <section id="torch-table">
+    <%= if length(@menu_categories) > 0 do %>
+      <table>
+        <thead>
+          <tr>
+            
+              <th><%= table_link(@conn, "Category", :category_id) %></th>
+            
+              <th><%= table_link(@conn, "Menu", :menu_id) %></th>
+            
+            <th><span>Actions</span></th>
+          </tr>
+        </thead>
+        <tbody>
+          <%= for menu_categories <- @menu_categories do %>
+            <tr>
+              
+                <td><%= menu_categories.category_id %></td>
+              
+                <td><%= menu_categories.menu_id %></td>
+              
+              <td class="torch-actions">
+                <span><%= link "Show", to: Routes.admin_menu_categories_path(@conn, :show, menu_categories) %></span>
+                <span><%= link "Edit", to: Routes.admin_menu_categories_path(@conn, :edit, menu_categories) %></span>
+                <span><%= link "Delete", to: Routes.admin_menu_categories_path(@conn, :delete, menu_categories), method: :delete, data: [confirm: "Are you sure?"] %></span>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+      <%= render Torch.PaginationView, "_pagination.html", assigns %>
+    <% else %>
+      <p class="torch-no-data">No Menu categories match your search.</p>
+    <% end %>
+    </section>
+  </div>
+</section>

--- a/lib/lunchbot_web/templates/admin/menu_categories/new.html.heex
+++ b/lib/lunchbot_web/templates/admin/menu_categories/new.html.heex
@@ -1,0 +1,14 @@
+<section id="torch-toolbar">
+  <div class="torch-container">
+    <%= link "Cancel", to: Routes.admin_menu_categories_path(@conn, :index), class: "torch-button" %>
+  </div>
+</section>
+
+<section id="torch-header-and-content">
+  <div class="torch-container">
+    <div class="header">
+      <h3>New Menu categories</h3>
+    </div>
+    <%= render "form.html", Map.put(assigns, :action, Routes.admin_menu_categories_path(@conn, :create)) %>
+  </div>
+</section>

--- a/lib/lunchbot_web/templates/admin/menu_categories/show.html.heex
+++ b/lib/lunchbot_web/templates/admin/menu_categories/show.html.heex
@@ -1,0 +1,27 @@
+<section id="torch-toolbar">
+  <div class="torch-container">
+    <%= link "Edit", to: Routes.admin_menu_categories_path(@conn, :edit, @menu_categories), class: "torch-button" %>
+    <%= link "Back", to: Routes.admin_menu_categories_path(@conn, :index), class: "torch-button" %>
+  </div>
+</section>
+
+<section id="torch-header-and-content">
+  <div class="torch-container">
+    <header class="header">
+      <h3>Menu categories Details</h3>
+    </header>
+    <section class="torch-show-details">
+      
+        <div class="torch-show-attribute">
+          <div class="torch-show-label">Category:</div>
+          <div class="torch-show-data"><%= @menu_categories.category_id %></div>
+        </div>
+      
+        <div class="torch-show-attribute">
+          <div class="torch-show-label">Menu:</div>
+          <div class="torch-show-data"><%= @menu_categories.menu_id %></div>
+        </div>
+      
+    </section>
+  </div>
+</section>

--- a/lib/lunchbot_web/views/admin/menu_categories_view.ex
+++ b/lib/lunchbot_web/views/admin/menu_categories_view.ex
@@ -1,0 +1,6 @@
+defmodule LunchbotWeb.Admin.MenuCategoriesView do
+  use LunchbotWeb, :view
+
+  import Torch.TableView
+  import Torch.FilterView
+end

--- a/priv/repo/migrations/20220720153427_add_more_fields.exs
+++ b/priv/repo/migrations/20220720153427_add_more_fields.exs
@@ -1,0 +1,11 @@
+defmodule Lunchbot.Repo.Migrations.AddMoreFields do
+  use Ecto.Migration
+
+  def change do
+    alter table(:items) do
+      add :description, :string
+      add :price, :integer
+      add :item_image, :string
+    end
+  end
+end

--- a/priv/repo/migrations/20220720182636_remove_menu_id_field.exs
+++ b/priv/repo/migrations/20220720182636_remove_menu_id_field.exs
@@ -1,0 +1,9 @@
+defmodule Lunchbot.Repo.Migrations.RemoveMenuIdField do
+  use Ecto.Migration
+
+  def change do
+    alter table(:categories) do
+      remove :menu_id
+    end
+  end
+end

--- a/priv/repo/migrations/20220720184249_create_menu_categories.exs
+++ b/priv/repo/migrations/20220720184249_create_menu_categories.exs
@@ -1,0 +1,12 @@
+defmodule Lunchbot.Repo.Migrations.CreateMenuCategories do
+  use Ecto.Migration
+
+  def change do
+    create table(:menu_categories) do
+      add :category_id, :integer
+      add :menu_id, :integer
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -9,3 +9,384 @@
 #
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
+
+alias Lunchbot.LunchbotData
+alias Lunchbot.LunchbotData.Menu
+alias Lunchbot.LunchbotData.Category
+alias Lunchbot.LunchbotData.MenuCategories
+alias Lunchbot.LunchbotData.Item
+alias Lunchbot.LunchbotData.OptionHeadings
+alias Lunchbot.LunchbotData.Options
+alias Lunchbot.LunchbotData.ItemOptionHeadings
+
+LunchbotData.create_office(%{
+  name: "Providence",
+  timezone: "EDT"
+})
+
+[
+  "Burrito Bowl",
+  "Kebob and Curry",
+  "Livi's Pockets",
+  "Ocean State Sandwich",
+  "PF Chang's",
+  "Saladworks",
+  "Sandwich Hut",
+  "Sicilia's",
+  "Sonia's"
+]
+|> Enum.each(fn name -> Lunchbot.Repo.insert!(%Menu{name: name, office_id: 1}) end)
+
+[
+  %{name: "Bowl"},
+  %{name: "Burrito"},
+  %{name: "Vegan / Gluten friendly Dishes w/rice"},
+  %{name: "Vegetarian / Gluten friendly Dishes w/rice"},
+  %{name: "Chicken Dishes w/rice"},
+  %{name: "Salad"},
+  %{name: "Sandwich"},
+  %{name: "Meals with rice"},
+  %{name: "Noodle dishes"},
+  %{name: "Salad / bowl base"},
+  %{name: "Included toppings"},
+  %{name: "Cold Sandwich"},
+  %{name: "Hot Sandwich"},
+  %{name: "Stuffed Pizza"},
+  %{name: "Regular/Thin Crust Pizza"}
+]
+|> Enum.each(fn ctg -> Lunchbot.Repo.insert!(%Category{name: ctg.name}) end)
+
+category_menus = [
+  %{name: "Burrito Bowl", categories: [%{name: "Bowl"}, %{name: "Burrito"}]},
+  %{
+    name: "Kebob and Curry",
+    categories: [
+      %{name: "Vegan / Gluten friendly Dishes w/rice"},
+      %{name: "Vegetarian / Gluten friendly Dishes w/rice"},
+      %{name: "Chicken Dishes w/rice"}
+    ]
+  },
+  %{name: "Livi's Pockets", categories: [%{name: "Salad"}, %{name: "Sandwich"}]},
+  %{name: "Ocean State Sandwich", categories: [%{name: "Salad"}, %{name: "Sandwich"}]},
+  %{name: "PF Chang's", categories: [%{name: "Meals with rice"}, %{name: "Noodle dishes"}]},
+  %{name: "Saladworks", categories: [%{name: "Salad / bowl base"}, %{name: "Included toppings"}]},
+  %{name: "Sandwich Hut", categories: [%{name: "Cold Sandwich"}, %{name: "Hot Sandwich"}]},
+  %{
+    name: "Sicilia's",
+    categories: [
+      %{name: "Salad"},
+      %{name: "Sandwich"},
+      %{name: "Stuffed Pizza"},
+      %{name: "Regular/Thin Crust Pizza"}
+    ]
+  },
+  %{name: "Sonia's", categories: [%{name: "Bowl"}, %{name: "Salad"}, %{name: "Sandwich"}]}
+]
+
+Enum.each(category_menus, fn menu ->
+  restaurant = Lunchbot.Repo.get_by!(Menu, name: "#{menu.name}")
+
+  Enum.each(menu.categories, fn ctg ->
+    category = Lunchbot.Repo.get_by!(Category, name: "#{ctg.name}")
+    Lunchbot.Repo.insert!(%MenuCategories{menu_id: restaurant.id, category_id: category.id})
+  end)
+end)
+
+category_items = [
+  %{name: "Bowl", items: [%{name: "Bowl", description: ""}]},
+  %{name: "Burrito", items: [%{name: "Burrito", description: ""}]},
+  %{
+    name: "Vegan / Gluten friendly Dishes w/rice",
+    items: [
+      %{name: "TOFU SAAG", description: "FINELY CHOPPED SPINACH, GINGER, GARLIC"},
+      %{name: "ALOO GOBHI", description: "POTATO, CAULIFLOWER, GINGER, ONION"},
+      %{name: "CHANA MASALA", description: "CHICKPEAS, ONION, GINGER, GARLIC"},
+      %{name: "BAINGAN BHARTA", description: "SMOKED EGGPLANT, TOMATO"},
+      %{name: "KATHAL & POTATO MASALA", description: "JACKFRUIT, GINGER, GARLIC"},
+      %{name: "TOFU MANGO CURRY", description: "FRESH VEGETABLES & STEAMED TOFU"}
+    ]
+  },
+  %{
+    name: "Vegetarian / Gluten friendly Dishes w/rice",
+    items: [
+      %{name: "TOFU MASALA", description: "CREAMY TOMATO SAUCE"},
+      %{
+        name: "EGG & POTATO CURRY",
+        description: "RED ONION, TOMATOES, GINGER & GARLIC"
+      },
+      %{
+        name: "PANEER (cheese) & PEPPER MAKHANI",
+        description: "CREAMY, TOMATO MASALA"
+      },
+      %{name: "MALAI KOFTA", description: "VEGETABLE CROQUETTES, CASHEWS & RAISINS"},
+      %{name: "PANEER MUSHROOM KORMA", description: "MUGHLAI SPICES & CASHEW PASTE"},
+      %{name: "MADRAS PANEER", description: "COCONUT, TOMATO, TAMARIND"},
+      %{name: "SAAG PANEER", description: "FINELY CHOPPED SPINACH, PANEER CHEESE"},
+      %{name: "VEGETABLE TIKKA MASALA", description: "CREAMY TOMATO MASALA"},
+      %{name: "PANEER TIKKA MASALA", description: "CREAMY, TOMATO MASALA"},
+      %{
+        name: "CHICKPEA POUTINE",
+        description:
+          "(no rice) Masala fries topped with chickpeas, scrambled tofu, and a creamy coconut masala sauce"
+      }
+    ]
+  },
+  %{
+    name: "Chicken Dishes w/rice",
+    items: [
+      %{name: "CHICKEN TIKKA MASALA", description: "CREAMY, TOMATO MASALA"},
+      %{name: "CHICKEN SAAG", description: "FINELY CHOPPED SPINACH, GINGER, GARLIC"},
+      %{name: "CHICKEN MUSHROOM KORMA", description: "NUTTY, CREAMY (contains nuts)"},
+      %{
+        name: "CHICKEN & POTATO VINDALOO",
+        description: "RED CHILI PASTE, VINEGAR (spicy)"
+      },
+      %{name: "MANGO CHICKEN", description: "ASSORTED VEGETABLES, CILANTRO"},
+      %{name: "MADRAS CHICKEN", description: "COCONUT, TOMATO, TAMARIND"},
+      %{name: "CHICKEN KADHAI", description: "ONIONS, PEPPERS"},
+      %{name: "CHICKEN CURRY", description: "ONION PASTE, GINGER, GARLIC"},
+      %{name: "CHICKEN TIKKA POUTINE", description: ""}
+    ]
+  },
+  %{
+    name: "Salad",
+    items: [
+      %{name: "GARDEN", description: ""},
+      %{name: "GREEK", description: ""},
+      %{name: "CAESAR", description: ""}
+    ]
+  },
+  %{
+    name: "Sandwich",
+    items: [
+      %{
+        name: "THE WORKS",
+        description:
+          "5 Falafel, Hummus, Tabouli, Pickles, Israeli Salad, Lettuce, Tomatoes & Tahini Dressing"
+      },
+      %{
+        name: "CRAZY VEGGIE",
+        description:
+          "Lettuce, Tomatoes, Carrots, Green Peppers, Onions, Roasted Red Peppers, Cucumbers, Feta Cheese, Hummus & Balsamic Vinaigrette"
+      },
+      %{
+        name: "LIVI'S POCKET",
+        description:
+          "lightly Breaded Eggplant, Fresh Mozzarella, Roasted Red Peppers, Lettuce & Balsamic Vinaigrette"
+      },
+      %{name: "MJEDRA", description: "(lentil,rice,onion) WRAP - with feta"},
+      %{name: "MJEDRA", description: "(lentil,rice,onion) WRAP - NO feta"},
+      %{
+        name: "CURRY CHICKEN",
+        description: "Curry Chicken Salad, Lettuce & Tomatoes"
+      },
+      %{
+        name: "CHICKEN & FALAFEL",
+        description:
+          "2 Grilled Chicken, 3 Falafel, Lettuce, Tomatoes, Hummus, Tabouli Salad & Tahini Dressing"
+      },
+      %{
+        name: "Chicken Club wrap",
+        description: "Grilled Chicken, Lettuce, Tomatoes, Applewood Smoked Bacon & Mayonnaise"
+      },
+      %{
+        name: "BUFFALO CHICKEN",
+        description: "3 Grilled Buffalo Chicken, Lettuce, Tomatoes & Blue Cheese Dressing"
+      },
+      %{
+        name: "Pesto Chicken",
+        description:
+          "Pesto, Grilled Chicken, Fresh Mozzarella, Lettuce, Tomatoes & Choice of Dressing"
+      },
+      %{
+        name: "GYRO",
+        description: "4 Grilled Beef, Lettuce, Tomatoes, Onions & Tzatziki Sauce"
+      },
+      %{
+        name: "GYRO & FALAFEL",
+        description: "4 Grilled Beef, Lettuce, Tomatoes, Onions & Tzatziki Sauce"
+      },
+      %{
+        name: "THE LIVINGSTON",
+        description: "Oven Gold Turkey Breast, Lettuce, Tomatoes, Honey Mustard & Mayonaise"
+      },
+      %{
+        name: "ITALIANO",
+        description:
+          "Ham, Genoa Salami, Prosciutto, Provolone, Lettuce, Tomatoes, Onions, Banana Peppers, Roasted Red Peppers & Balsamic Vinaigrette"
+      },
+      %{
+        name: "BLT",
+        description: "Applewood Smoked Bacon, Lettuce, Tomatoes & Mayonaise"
+      },
+      %{
+        name: "Classic Tuna",
+        description: "Tuna, Lettuce, Tomatoes, Pickles, & Banana Peppers"
+      },
+      %{
+        name: "Kofta Kabob wrap",
+        description: "Seasoned Ground Beef, Onions, Lettuce, Tomatoes, Hummus & Tahini Dressing"
+      },
+      %{
+        name: "Lamb Kabob wrap",
+        description: "Lamb Kabob, Lettuce, Tomatoes, & Grilled Onions + Peppers"
+      },
+      %{
+        name: "Leopold",
+        description:
+          "Ham, Cheese, Lettuce, Tomatoes, Honey Mustard & Mayonaise Choice of American, Swiss, or Provolone Cheese"
+      }
+    ]
+  }
+  # %{name: "Meals with rice"},
+  # %{name: "Noodle dishes"},
+  # %{name: "Salad / bowl base"},
+  # %{name: "Included toppings"},
+  # %{name: "Cold Sandwich"},
+  # %{name: "Hot Sandwich"},
+  # %{name: "Stuffed Pizza"},
+  # %{name: "Regular/Thin Crust Pizza"}
+]
+
+Enum.each(category_items, fn ctg ->
+  category = Lunchbot.Repo.get_by!(Category, name: "#{ctg.name}")
+
+  Enum.each(ctg.items, fn item ->
+    Lunchbot.Repo.insert!(%Item{
+      name: item.name,
+      description: item.description,
+      category_id: category.id
+    })
+  end)
+end)
+
+headings =
+  [
+    %{name: "Protein", priority: 1},
+    %{name: "Toppings", priority: 2},
+    %{name: "Spice Level", priority: 1},
+    %{name: "Dressing", priority: 2}
+  ]
+  |> Enum.each(fn hdg ->
+    Lunchbot.Repo.insert!(%OptionHeadings{name: hdg.name, priority: hdg.priority})
+  end)
+
+heading_options = [
+  %{
+    name: "Protein",
+    option: [
+      %{name: "Chicken"},
+      %{name: "Ground Beef"},
+      %{name: "Steak"},
+      %{name: "Pork"},
+      %{name: "Veggies"},
+      %{name: "Tofu"},
+      %{name: "No Protein"},
+      %{name: "Grilled Chicken"},
+      %{name: "Falafel"},
+      %{name: "Gyro"},
+      %{name: "Kofta (meatball)"},
+      %{name: "Shredded lemon chicken"},
+      %{name: "Mjedra (rice & lentils)"}
+    ]
+  },
+  %{
+    name: "Toppings",
+    option: [
+      %{name: "White rice"},
+      %{name: "Brown rice"},
+      %{name: "Cheese"},
+      %{name: "Black beans"},
+      %{name: "Pinto beans"},
+      %{name: "Lettuce"},
+      %{name: "Tomato"},
+      %{name: "Tom Salsa"},
+      %{name: "Corn salsa"},
+      %{name: "Guacamole"},
+      %{name: "Cilantro"},
+      %{name: "Sour cream"}
+    ]
+  },
+  %{name: "Spice Level", option: [%{name: "Regular"}, %{name: "Medium"}, %{name: "H-O-T!"}]},
+  %{
+    name: "Dressing",
+    option: [
+      %{name: "Tahani"},
+      %{name: "Balsamic Vinaigrette"},
+      %{name: "Honey Mustard"},
+      %{name: "Greek"},
+      %{name: "Italian"},
+      %{name: "Blue Cheese"},
+      %{name: "Caesar"}
+    ]
+  }
+]
+
+Enum.each(heading_options, fn hdg ->
+  heading = Lunchbot.Repo.get_by!(OptionHeadings, name: "#{hdg.name}")
+
+  Enum.each(hdg.option, fn option ->
+    Lunchbot.Repo.insert!(%Options{
+      name: option.name,
+      option_heading_id: heading.id
+    })
+  end)
+end)
+
+heading_items = [
+  %{
+    name: "Protein",
+    items: [
+      %{name: "Bowl"},
+      %{name: "Burrito"},
+      %{name: "GARDEN"},
+      %{name: "GREEK"},
+      %{name: "CAESAR"}
+    ]
+  },
+  %{name: "Toppings", items: [%{name: "Bowl"}, %{name: "Burrito"}]},
+  %{
+    name: "Spice Level",
+    items: [
+      %{name: "TOFU SAAG"},
+      %{name: "ALOO GOBHI"},
+      %{name: "CHANA MASALA"},
+      %{name: "BAINGAN BHARTA"},
+      %{name: "KATHAL & POTATO MASALA"},
+      %{name: "TOFU MANGO CURRY"},
+      %{name: "TOFU MASALA"},
+      %{name: "EGG & POTATO CURRY"},
+      %{name: "PANEER (cheese) & PEPPER MAKHANI"},
+      %{name: "MALAI KOFTA"},
+      %{name: "PANEER MUSHROOM KORMA"},
+      %{name: "MADRAS PANEER"},
+      %{name: "SAAG PANEER"},
+      %{name: "VEGETABLE TIKKA MASALA"},
+      %{name: "PANEER TIKKA MASALA"},
+      %{name: "CHICKPEA POUTINE"},
+      %{name: "CHICKEN TIKKA MASALA"},
+      %{name: "CHICKEN SAAG"},
+      %{name: "CHICKEN MUSHROOM KORMA"},
+      %{name: "CHICKEN & POTATO VINDALOO"},
+      %{name: "MANGO CHICKEN"},
+      %{name: "MADRAS CHICKEN"},
+      %{name: "CHICKEN KADHAI"},
+      %{name: "CHICKEN CURRY"},
+      %{name: "CHICKEN TIKKA POUTINE"}
+    ]
+  },
+  %{name: "Dressing", items: [%{name: "GARDEN"}, %{name: "GREEK"}, %{name: "CAESAR"}]}
+]
+
+Enum.each(heading_items, fn hdg ->
+  heading = Lunchbot.Repo.get_by!(OptionHeadings, name: "#{hdg.name}")
+
+  Enum.each(hdg.items, fn item ->
+    item = Lunchbot.Repo.get_by!(Item, name: "#{item.name}")
+
+    Lunchbot.Repo.insert!(%ItemOptionHeadings{
+      item_id: item.id,
+      option_heading_id: heading.id
+    })
+  end)
+end)

--- a/test/lunchbot/lunchbot_data_test.exs
+++ b/test/lunchbot/lunchbot_data_test.exs
@@ -499,9 +499,9 @@ defmodule Lunchbot.LunchbotDataTest do
 
   alias Lunchbot.LunchbotData.Category
 
-  @valid_attrs %{menu_id: 42, name: "some name"}
-  @update_attrs %{menu_id: 43, name: "some updated name"}
-  @invalid_attrs %{menu_id: nil, name: nil}
+  @valid_attrs %{name: "some name"}
+  @update_attrs %{name: "some updated name"}
+  @invalid_attrs %{name: nil}
 
   describe "#paginate_categories/1" do
     test "returns paginated list of categories" do
@@ -539,7 +539,6 @@ defmodule Lunchbot.LunchbotDataTest do
   describe "#create_category/1" do
     test "with valid data creates a category" do
       assert {:ok, %Category{} = category} = LunchbotData.create_category(@valid_attrs)
-      assert category.menu_id == 42
       assert category.name == "some name"
     end
 
@@ -553,7 +552,6 @@ defmodule Lunchbot.LunchbotDataTest do
       category = category_fixture()
       assert {:ok, category} = LunchbotData.update_category(category, @update_attrs)
       assert %Category{} = category
-      assert category.menu_id == 43
       assert category.name == "some updated name"
     end
 
@@ -1242,5 +1240,108 @@ defmodule Lunchbot.LunchbotDataTest do
       |> LunchbotData.create_options()
 
     options
+  end
+
+  alias Lunchbot.LunchbotData.MenuCategories
+
+  @valid_attrs %{category_id: 42, menu_id: 42}
+  @update_attrs %{category_id: 43, menu_id: 43}
+  @invalid_attrs %{category_id: nil, menu_id: nil}
+
+  describe "#paginate_menu_categories/1" do
+    test "returns paginated list of menu_categories" do
+      for _ <- 1..20 do
+        menu_categories_fixture()
+      end
+
+      {:ok, %{menu_categories: menu_categories} = page} =
+        LunchbotData.paginate_menu_categories(%{})
+
+      assert length(menu_categories) == 15
+      assert page.page_number == 1
+      assert page.page_size == 15
+      assert page.total_pages == 2
+      assert page.total_entries == 20
+      assert page.distance == 5
+      assert page.sort_field == "inserted_at"
+      assert page.sort_direction == "desc"
+    end
+  end
+
+  describe "#list_menu_categories/0" do
+    test "returns all menu_categories" do
+      menu_categories = menu_categories_fixture()
+      assert LunchbotData.list_menu_categories() == [menu_categories]
+    end
+  end
+
+  describe "#get_menu_categories!/1" do
+    test "returns the menu_categories with given id" do
+      menu_categories = menu_categories_fixture()
+      assert LunchbotData.get_menu_categories!(menu_categories.id) == menu_categories
+    end
+  end
+
+  describe "#create_menu_categories/1" do
+    test "with valid data creates a menu_categories" do
+      assert {:ok, %MenuCategories{} = menu_categories} =
+               LunchbotData.create_menu_categories(@valid_attrs)
+
+      assert menu_categories.category_id == 42
+      assert menu_categories.menu_id == 42
+    end
+
+    test "with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = LunchbotData.create_menu_categories(@invalid_attrs)
+    end
+  end
+
+  describe "#update_menu_categories/2" do
+    test "with valid data updates the menu_categories" do
+      menu_categories = menu_categories_fixture()
+
+      assert {:ok, menu_categories} =
+               LunchbotData.update_menu_categories(menu_categories, @update_attrs)
+
+      assert %MenuCategories{} = menu_categories
+      assert menu_categories.category_id == 43
+      assert menu_categories.menu_id == 43
+    end
+
+    test "with invalid data returns error changeset" do
+      menu_categories = menu_categories_fixture()
+
+      assert {:error, %Ecto.Changeset{}} =
+               LunchbotData.update_menu_categories(menu_categories, @invalid_attrs)
+
+      assert menu_categories == LunchbotData.get_menu_categories!(menu_categories.id)
+    end
+  end
+
+  describe "#delete_menu_categories/1" do
+    test "deletes the menu_categories" do
+      menu_categories = menu_categories_fixture()
+      assert {:ok, %MenuCategories{}} = LunchbotData.delete_menu_categories(menu_categories)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        LunchbotData.get_menu_categories!(menu_categories.id)
+      end
+    end
+  end
+
+  describe "#change_menu_categories/1" do
+    test "returns a menu_categories changeset" do
+      menu_categories = menu_categories_fixture()
+      assert %Ecto.Changeset{} = LunchbotData.change_menu_categories(menu_categories)
+    end
+  end
+
+  def menu_categories_fixture(attrs \\ %{}) do
+    {:ok, menu_categories} =
+      attrs
+      |> Enum.into(@valid_attrs)
+      |> LunchbotData.create_menu_categories()
+
+    menu_categories
   end
 end

--- a/test/lunchbot/lunchbot_data_test.exs
+++ b/test/lunchbot/lunchbot_data_test.exs
@@ -684,14 +684,30 @@ defmodule Lunchbot.LunchbotDataTest do
 
   alias Lunchbot.LunchbotData.Item
 
-  @valid_attrs %{category_id: 42, deleted: true, image_url: "some image_url", name: "some name"}
+  @valid_attrs %{
+    category_id: 42,
+    deleted: true,
+    description: "some description",
+    image_url: "some image_url",
+    name: "some name",
+    price: 10
+  }
   @update_attrs %{
     category_id: 43,
     deleted: false,
+    description: "some updated description",
     image_url: "some updated image_url",
-    name: "some updated name"
+    name: "some updated name",
+    price: 11
   }
-  @invalid_attrs %{category_id: nil, deleted: nil, image_url: nil, name: nil}
+  @invalid_attrs %{
+    category_id: nil,
+    deleted: nil,
+    description: nil,
+    image_url: nil,
+    name: nil,
+    price: nil
+  }
 
   describe "#paginate_items/1" do
     test "returns paginated list of items" do
@@ -733,6 +749,8 @@ defmodule Lunchbot.LunchbotDataTest do
       assert item.deleted == true
       assert item.image_url == "some image_url"
       assert item.name == "some name"
+      assert item.description == "some description"
+      assert item.price == 10
     end
 
     test "with invalid data returns error changeset" do
@@ -749,6 +767,8 @@ defmodule Lunchbot.LunchbotDataTest do
       assert item.deleted == false
       assert item.image_url == "some updated image_url"
       assert item.name == "some updated name"
+      assert item.description == "some updated description"
+      assert item.price == 11
     end
 
     test "with invalid data returns error changeset" do

--- a/test/lunchbot_web/controllers/admin/category_controller_test.exs
+++ b/test/lunchbot_web/controllers/admin/category_controller_test.exs
@@ -3,9 +3,9 @@ defmodule LunchbotWeb.Admin.CategoryControllerTest do
 
   alias Lunchbot.LunchbotData
 
-  @create_attrs %{menu_id: 42, name: "some name"}
-  @update_attrs %{menu_id: 43, name: "some updated name"}
-  @invalid_attrs %{menu_id: nil, name: nil}
+  @create_attrs %{name: "some name"}
+  @update_attrs %{name: "some updated name"}
+  @invalid_attrs %{name: nil}
 
   def fixture(:category) do
     {:ok, category} = LunchbotData.create_category(@create_attrs)

--- a/test/lunchbot_web/controllers/admin/item_controller_test.exs
+++ b/test/lunchbot_web/controllers/admin/item_controller_test.exs
@@ -3,14 +3,30 @@ defmodule LunchbotWeb.Admin.ItemControllerTest do
 
   alias Lunchbot.LunchbotData
 
-  @create_attrs %{category_id: 42, deleted: true, image_url: "some image_url", name: "some name"}
+  @create_attrs %{
+    category_id: 42,
+    deleted: true,
+    description: "some description",
+    image_url: "some image_url",
+    name: "some name",
+    price: 10
+  }
   @update_attrs %{
     category_id: 43,
     deleted: false,
+    description: "some updated description",
     image_url: "some updated image_url",
-    name: "some updated name"
+    name: "some updated name",
+    price: 11
   }
-  @invalid_attrs %{category_id: nil, deleted: nil, image_url: nil, name: nil}
+  @invalid_attrs %{
+    category_id: nil,
+    deleted: nil,
+    description: nil,
+    image_url: nil,
+    name: nil,
+    price: nil
+  }
 
   def fixture(:item) do
     {:ok, item} = LunchbotData.create_item(@create_attrs)

--- a/test/lunchbot_web/controllers/admin/menu_categories_controller_test.exs
+++ b/test/lunchbot_web/controllers/admin/menu_categories_controller_test.exs
@@ -1,0 +1,108 @@
+defmodule LunchbotWeb.Admin.MenuCategoriesControllerTest do
+  use LunchbotWeb.ConnCase
+
+  alias Lunchbot.LunchbotData
+
+  @create_attrs %{category_id: 42, menu_id: 42}
+  @update_attrs %{category_id: 43, menu_id: 43}
+  @invalid_attrs %{category_id: nil, menu_id: nil}
+
+  def fixture(:menu_categories) do
+    {:ok, menu_categories} = LunchbotData.create_menu_categories(@create_attrs)
+    menu_categories
+  end
+
+  setup do
+    initialize_admin_user()
+  end
+
+  describe "index" do
+    test "lists all menu_categories", %{conn: conn} do
+      conn = get(conn, Routes.admin_menu_categories_path(conn, :index))
+      assert html_response(conn, 200) =~ "Menu categories"
+    end
+  end
+
+  describe "new menu_categories" do
+    test "renders form", %{conn: conn} do
+      conn = get(conn, Routes.admin_menu_categories_path(conn, :new))
+      assert html_response(conn, 200) =~ "New Menu categories"
+    end
+  end
+
+  describe "create menu_categories" do
+    test "redirects to show when data is valid", %{conn: conn} do
+      conn =
+        post conn, Routes.admin_menu_categories_path(conn, :create),
+          menu_categories: @create_attrs
+
+      assert %{id: id} = redirected_params(conn)
+      assert redirected_to(conn) == Routes.admin_menu_categories_path(conn, :show, id)
+
+      conn = get(conn, Routes.admin_menu_categories_path(conn, :show, id))
+      assert html_response(conn, 200) =~ "Menu categories Details"
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn =
+        post conn, Routes.admin_menu_categories_path(conn, :create),
+          menu_categories: @invalid_attrs
+
+      assert html_response(conn, 200) =~ "New Menu categories"
+    end
+  end
+
+  describe "edit menu_categories" do
+    setup [:create_menu_categories]
+
+    test "renders form for editing chosen menu_categories", %{
+      conn: conn,
+      menu_categories: menu_categories
+    } do
+      conn = get(conn, Routes.admin_menu_categories_path(conn, :edit, menu_categories))
+      assert html_response(conn, 200) =~ "Edit Menu categories"
+    end
+  end
+
+  describe "update menu_categories" do
+    setup [:create_menu_categories]
+
+    test "redirects when data is valid", %{conn: conn, menu_categories: menu_categories} do
+      conn =
+        put conn, Routes.admin_menu_categories_path(conn, :update, menu_categories),
+          menu_categories: @update_attrs
+
+      assert redirected_to(conn) ==
+               Routes.admin_menu_categories_path(conn, :show, menu_categories)
+
+      conn = get(conn, Routes.admin_menu_categories_path(conn, :show, menu_categories))
+      assert html_response(conn, 200)
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, menu_categories: menu_categories} do
+      conn =
+        put conn, Routes.admin_menu_categories_path(conn, :update, menu_categories),
+          menu_categories: @invalid_attrs
+
+      assert html_response(conn, 200) =~ "Edit Menu categories"
+    end
+  end
+
+  describe "delete menu_categories" do
+    setup [:create_menu_categories]
+
+    test "deletes chosen menu_categories", %{conn: conn, menu_categories: menu_categories} do
+      conn = delete(conn, Routes.admin_menu_categories_path(conn, :delete, menu_categories))
+      assert redirected_to(conn) == Routes.admin_menu_categories_path(conn, :index)
+
+      assert_error_sent 404, fn ->
+        get(conn, Routes.admin_menu_categories_path(conn, :show, menu_categories))
+      end
+    end
+  end
+
+  defp create_menu_categories(_) do
+    menu_categories = fixture(:menu_categories)
+    {:ok, menu_categories: menu_categories}
+  end
+end

--- a/test/support/fixtures/lunchbot_data_fixtures.ex
+++ b/test/support/fixtures/lunchbot_data_fixtures.ex
@@ -90,7 +90,6 @@ defmodule Lunchbot.LunchbotDataFixtures do
     {:ok, category} =
       attrs
       |> Enum.into(%{
-        menu_id: 42,
         name: "some name"
       })
       |> Lunchbot.LunchbotData.create_category()
@@ -195,5 +194,20 @@ defmodule Lunchbot.LunchbotDataFixtures do
       |> Lunchbot.LunchbotData.create_options()
 
     options
+  end
+
+  @doc """
+  Generate a menu_categories.
+  """
+  def menu_categories_fixture(attrs \\ %{}) do
+    {:ok, menu_categories} =
+      attrs
+      |> Enum.into(%{
+        category_id: 42,
+        menu_id: 42
+      })
+      |> Lunchbot.LunchbotData.create_menu_categories()
+
+    menu_categories
   end
 end

--- a/test/support/fixtures/lunchbot_data_fixtures.ex
+++ b/test/support/fixtures/lunchbot_data_fixtures.ex
@@ -122,8 +122,10 @@ defmodule Lunchbot.LunchbotDataFixtures do
       |> Enum.into(%{
         category_id: 42,
         deleted: true,
+        description: "some description",
         image_url: "some image_url",
-        name: "some name"
+        name: "some name",
+        price: 10
       })
       |> Lunchbot.LunchbotData.create_item()
 


### PR DESCRIPTION
So far I have the first 3 menus data seeded. While working with PVD’s data, I notice things that were missing from our data model and database. I added 3 new fields (price, description, and item_image). I also realized that the relationship between menus and categories is many-to-many (ie. Menus have many different categories and a category, for example salad, can be found on many different menus). This seed file properly populates the normalized database. We came to a consensus to use elixir maps when seeding the db. Keeping the join tables allows the team to use Ecto’s built-in many-to-many relationships to handle their queries.
<img width="467" alt="DB structure for currect seeding" src="https://user-images.githubusercontent.com/58053105/180492441-19a56aa7-628e-4866-800c-847058d0b9b0.png">
