### PR TITLE
feat: User creates an order

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -118,3 +118,87 @@
   0% { opacity: 1; }
   100% { opacity: 0; }
 }
+
+.modal-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  overflow-y: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 998;
+  background-color: rgba(0, 0, 0, 0.7);
+}
+
+.modal-inner-container {
+  position: relative;
+  z-index: 999;
+}
+
+.modal-card {
+  height: auto;
+  width: 28rem;
+  max-width: 51rem;
+  margin: 0.5rem;
+  border-radius: 0.4rem;
+  background-color: #fff;
+}
+
+.modal-inner-card {
+  padding-top: 1rem;
+  padding-bottom: 0.5rem;
+  padding-left: 2.25rem;
+  padding-right: 2.25rem;
+}
+
+.modal-title {
+  color: #0069d9;
+  text-transform: uppercase;
+  text-align: center;
+  font-weight: 600;
+  font-size: 1.5rem;
+  letter-spacing: 0.075em;
+}
+
+.modal-form-title {
+  color: #000;
+  text-transform: uppercase;
+  text-align: center;
+  font-weight: 600;
+  font-size: 1.5rem;
+  letter-spacing: 0.075em;
+  margin-bottom: 1.75rem;
+}
+
+.modal-body {
+  margin-top: 0.8rem;
+  text-align: center;
+  font-size: 1.6rem;
+}
+
+.modal-buttons {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 1.75rem;
+}
+
+.left-button {
+  color: #31708f;
+  background-color: #d9edf7;
+  border-color: #bce8f1;
+}
+
+.right-button {
+  margin-left: 0.6rem;
+}
+
+.fix-position {
+  position: fixed;
+  right: 0;
+  left: 0;
+  overflow: hidden;
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -20,14 +20,52 @@ import "../css/app.css"
 //
 
 // Include phoenix_html to handle method=PUT/DELETE in forms and buttons.
-import "phoenix_html"
+import 'phoenix_html'
 // Establish Phoenix Socket and LiveView configuration.
-import {Socket} from "phoenix"
-import {LiveSocket} from "phoenix_live_view"
+import {Socket} from 'phoenix'
+import {LiveSocket} from 'phoenix_live_view'
 import topbar from "../vendor/topbar"
 
-let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
-let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}})
+// Define hooks
+const Hooks = {}
+Hooks.ScrollLock = {
+  mounted() {
+    this.lockScroll()
+  },
+  destroyed() {
+    this.unlockScroll()
+  },
+  lockScroll() {
+    // From https://github.com/excid3/tailwindcss-stimulus-components/blob/master/src/modal.js
+    // Add right padding to the body so the page doesn't shift when we disable scrolling
+    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth
+    document.body.style.paddingRight = `${scrollbarWidth}px`
+    // Save the scroll position
+    this.scrollPosition = window.pageYOffset || document.body.scrollTop
+    // Add classes to body to fix its position
+    document.body.classList.add('fix-position')
+    // Add negative top position in order for body to stay in place
+    document.body.style.top = `-${this.scrollPosition}px`
+  },
+  unlockScroll() {
+    // From https://github.com/excid3/tailwindcss-stimulus-components/blob/master/src/modal.js
+    // Remove tweaks for scrollbar
+    document.body.style.paddingRight = null
+    // Remove classes from body to unfix position
+    document.body.classList.remove('fix-position')
+    // Restore the scroll position of the body before it got locked
+    document.documentElement.scrollTop = this.scrollPosition
+    // Remove the negative top inline style from body
+    document.body.style.top = null
+  }
+}
+let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content");
+let liveSocket = new LiveSocket("/live", Socket, {
+  params: {
+    _csrf_token: csrfToken
+  },
+  hooks: Hooks
+});
 
 // Show progress bar on live navigation and form submits
 topbar.config({barColors: {0: "#29d"}, shadowColor: "rgba(0, 0, 0, .3)"})

--- a/lib/lunchbot/lunchbot_data.ex
+++ b/lib/lunchbot/lunchbot_data.ex
@@ -1210,7 +1210,7 @@ defmodule Lunchbot.LunchbotData do
   import Torch.Helpers, only: [sort: 1, paginate: 4, strip_unset_booleans: 3]
   import Filtrex.Type.Config
 
-  alias Lunchbot.LunchbotData.OptionHeadings
+  alias Lunchbot.LunchbotData.OptionHeading
 
   @pagination [page_size: 15]
   @pagination_distance 5
@@ -1257,7 +1257,7 @@ defmodule Lunchbot.LunchbotData do
   end
 
   defp do_paginate_option_headings(filter, params) do
-    OptionHeadings
+    OptionHeading
     |> Filtrex.query(filter)
     |> order_by(^sort(params))
     |> paginate(Repo, params, @pagination)
@@ -1269,11 +1269,11 @@ defmodule Lunchbot.LunchbotData do
   ## Examples
 
       iex> list_option_headings()
-      [%OptionHeadings{}, ...]
+      [%OptionHeading{}, ...]
 
   """
   def list_option_headings do
-    Repo.all(OptionHeadings)
+    Repo.all(OptionHeading)
   end
 
   @doc """
@@ -1290,7 +1290,7 @@ defmodule Lunchbot.LunchbotData do
       ** (Ecto.NoResultsError)
 
   """
-  def get_option_headings!(id), do: Repo.get!(OptionHeadings, id)
+  def get_option_headings!(id), do: Repo.get!(OptionHeading, id)
 
   @doc """
   Creates a option_headings.
@@ -1298,15 +1298,15 @@ defmodule Lunchbot.LunchbotData do
   ## Examples
 
       iex> create_option_headings(%{field: value})
-      {:ok, %OptionHeadings{}}
+      {:ok, %OptionHeading{}}
 
       iex> create_option_headings(%{field: bad_value})
       {:error, %Ecto.Changeset{}}
 
   """
   def create_option_headings(attrs \\ %{}) do
-    %OptionHeadings{}
-    |> OptionHeadings.changeset(attrs)
+    %OptionHeading{}
+    |> OptionHeading.changeset(attrs)
     |> Repo.insert()
   end
 
@@ -1322,9 +1322,9 @@ defmodule Lunchbot.LunchbotData do
       {:error, %Ecto.Changeset{}}
 
   """
-  def update_option_headings(%OptionHeadings{} = option_headings, attrs) do
+  def update_option_headings(%OptionHeading{} = option_headings, attrs) do
     option_headings
-    |> OptionHeadings.changeset(attrs)
+    |> OptionHeading.changeset(attrs)
     |> Repo.update()
   end
 
@@ -1340,7 +1340,7 @@ defmodule Lunchbot.LunchbotData do
       {:error, %Ecto.Changeset{}}
 
   """
-  def delete_option_headings(%OptionHeadings{} = option_headings) do
+  def delete_option_headings(%OptionHeading{} = option_headings) do
     Repo.delete(option_headings)
   end
 
@@ -1350,11 +1350,11 @@ defmodule Lunchbot.LunchbotData do
   ## Examples
 
       iex> change_option_headings(option_headings)
-      %Ecto.Changeset{source: %OptionHeadings{}}
+      %Ecto.Changeset{source: %OptionHeading{}}
 
   """
-  def change_option_headings(%OptionHeadings{} = option_headings, attrs \\ %{}) do
-    OptionHeadings.changeset(option_headings, attrs)
+  def change_option_headings(%OptionHeading{} = option_headings, attrs \\ %{}) do
+    OptionHeading.changeset(option_headings, attrs)
   end
 
   import Torch.Helpers, only: [sort: 1, paginate: 4, strip_unset_booleans: 3]

--- a/lib/lunchbot/lunchbot_data/category.ex
+++ b/lib/lunchbot/lunchbot_data/category.ex
@@ -3,7 +3,9 @@ defmodule Lunchbot.LunchbotData.Category do
   import Ecto.Changeset
 
   schema "categories" do
+    many_to_many :menus, Lunchbot.LunchbotData.Menu, join_through: "menu_categories"
     field :name, :string
+    has_many :items, Lunchbot.LunchbotData.Item
 
     timestamps()
   end

--- a/lib/lunchbot/lunchbot_data/item.ex
+++ b/lib/lunchbot/lunchbot_data/item.ex
@@ -3,13 +3,16 @@ defmodule Lunchbot.LunchbotData.Item do
   import Ecto.Changeset
 
   schema "items" do
-    field :category_id, :integer
+    belongs_to :category, Lunchbot.LunchbotData.Category
     field :deleted, :boolean, default: false
     field :description, :string
     field :image_url, :string
     field :item_image, :string
     field :name, :string
     field :price, :integer
+
+    many_to_many :option_headings, Lunchbot.LunchbotData.OptionHeading,
+      join_through: "item_option_headings"
 
     timestamps()
   end

--- a/lib/lunchbot/lunchbot_data/item_option_headings.ex
+++ b/lib/lunchbot/lunchbot_data/item_option_headings.ex
@@ -3,8 +3,8 @@ defmodule Lunchbot.LunchbotData.ItemOptionHeadings do
   import Ecto.Changeset
 
   schema "item_option_headings" do
-    field :item_id, :integer
-    field :option_heading_id, :integer
+    belongs_to :item, Lunchbot.LunchbotData.Item
+    belongs_to :option_heading, Lunchbot.LunchbotData.OptionHeading
 
     timestamps()
   end

--- a/lib/lunchbot/lunchbot_data/menu.ex
+++ b/lib/lunchbot/lunchbot_data/menu.ex
@@ -5,6 +5,7 @@ defmodule Lunchbot.LunchbotData.Menu do
   schema "menus" do
     field :name, :string
     field :office_id, :integer
+    many_to_many :categories, Lunchbot.LunchbotData.Category, join_through: "menu_categories"
 
     timestamps()
   end

--- a/lib/lunchbot/lunchbot_data/menu_categories.ex
+++ b/lib/lunchbot/lunchbot_data/menu_categories.ex
@@ -3,8 +3,8 @@ defmodule Lunchbot.LunchbotData.MenuCategories do
   import Ecto.Changeset
 
   schema "menu_categories" do
-    field :category_id, :integer
-    field :menu_id, :integer
+    belongs_to :category, Lunchbot.LunchbotData.Category
+    belongs_to :menu, Lunchbot.LunchbotData.Menu
 
     timestamps()
   end

--- a/lib/lunchbot/lunchbot_data/option_headings.ex
+++ b/lib/lunchbot/lunchbot_data/option_headings.ex
@@ -1,10 +1,12 @@
-defmodule Lunchbot.LunchbotData.OptionHeadings do
+defmodule Lunchbot.LunchbotData.OptionHeading do
   use Ecto.Schema
   import Ecto.Changeset
 
   schema "option_headings" do
+    many_to_many :items, Lunchbot.LunchbotData.Item, join_through: "item_option_headings"
     field :name, :string
     field :priority, :integer
+    has_many :options, Lunchbot.LunchbotData.Options
 
     timestamps()
   end

--- a/lib/lunchbot/lunchbot_data/options.ex
+++ b/lib/lunchbot/lunchbot_data/options.ex
@@ -3,11 +3,11 @@ defmodule Lunchbot.LunchbotData.Options do
   import Ecto.Changeset
 
   schema "options" do
+    belongs_to :option_heading, Lunchbot.LunchbotData.OptionHeading
     field :extra_price, :integer
     field :extras, :boolean, default: false
     field :is_required, :boolean, default: false
     field :name, :string
-    field :option_heading_id, :integer
     field :preselected, :boolean, default: false
     field :price, :integer
 

--- a/lib/lunchbot_web/controllers/admin/option_headings_controller.ex
+++ b/lib/lunchbot_web/controllers/admin/option_headings_controller.ex
@@ -2,7 +2,7 @@ defmodule LunchbotWeb.Admin.OptionHeadingsController do
   use LunchbotWeb, :controller
 
   alias Lunchbot.LunchbotData
-  alias Lunchbot.LunchbotData.OptionHeadings
+  alias Lunchbot.LunchbotData.OptionHeading
 
   plug(:put_root_layout, {LunchbotWeb.LayoutView, "torch.html"})
   plug(:put_layout, false)
@@ -20,7 +20,7 @@ defmodule LunchbotWeb.Admin.OptionHeadingsController do
   end
 
   def new(conn, _params) do
-    changeset = LunchbotData.change_option_headings(%OptionHeadings{})
+    changeset = LunchbotData.change_option_headings(%OptionHeading{})
     render(conn, "new.html", changeset: changeset)
   end
 

--- a/lib/lunchbot_web/live/components/modal.ex
+++ b/lib/lunchbot_web/live/components/modal.ex
@@ -1,0 +1,145 @@
+defmodule LunchbotWeb.LiveComponent.ModalLive do
+  use Phoenix.LiveComponent
+
+  import Phoenix.HTML.Form
+
+  @defaults %{
+    left_button: "Close",
+    left_button_action: nil,
+    left_button_param: nil,
+    right_button: "Submit",
+    right_button_action: nil,
+    right_button_param: nil
+  }
+
+  def mount(socket) do
+    {:ok, assign(socket, :selected_options, [])}
+  end
+
+  def update(%{id: _id} = assigns, socket) do
+    {:ok, assign(socket, Map.merge(@defaults, assigns))}
+  end
+
+  def handle_event(
+        "change_button",
+        params,
+        socket
+      ) do
+    target_item = params["_target"] |> Enum.at(0)
+
+    socket =
+      if(Enum.member?(socket.assigns.selected_options, target_item)) do
+        assign(
+          socket,
+          :selected_options,
+          List.delete(socket.assigns.selected_options, target_item)
+        )
+      else
+        assign(socket, :selected_options, [target_item | socket.assigns.selected_options])
+      end
+
+    {:noreply, socket}
+  end
+
+  # Fired when user clicks right button on modal
+  def handle_event(
+        "right-button-click",
+        _params,
+        %{
+          assigns: %{
+            right_button_action: right_button_action,
+            right_button_param: _right_button_param
+          }
+        } = socket
+      ) do
+    send(
+      self(),
+      {__MODULE__, :button_clicked,
+       %{
+         action: right_button_action,
+         param: %{id: socket.assigns.id, selected_options: socket.assigns.selected_options}
+       }}
+    )
+
+    {:noreply, socket}
+  end
+
+  def handle_event(
+        "left-button-click",
+        _params,
+        %{
+          assigns: %{
+            left_button_action: left_button_action,
+            left_button_param: left_button_param
+          }
+        } = socket
+      ) do
+    send(
+      self(),
+      {__MODULE__, :button_clicked, %{action: left_button_action, param: left_button_param}}
+    )
+
+    {:noreply, socket}
+  end
+
+  def render(assigns) do
+    ~H"""
+      <div id={"modal-#{@id}"}>
+      <!-- Modal Background -->
+      <div class="modal-container"
+          id={"item-#{@id}"}
+          phx-hook="ScrollLock">
+        <div class="modal-inner-container">
+          <div class="modal-card">
+            <div class="modal-inner-card">
+              <!-- Title -->
+              <%= if @title != nil do %>
+              <div class="modal-title">
+                <%= @title %>
+              </div>
+              <% end %>
+
+              <!-- Body -->
+              <%= if @body != nil do %>
+                <%= f = form_for :add_options, "#", id: @id, phx_change: "change_button", phx_target: @myself %>
+                <div class="modal-body">
+                <%= label f, :options, "Submit your item:" %>
+                <%= for option_headings <- @body do %>
+                  <h3><%= option_headings.name %></h3>
+                  <%= for options <- option_headings.options do %>
+                    <%= checkbox(f, :options, name: "#{options.name}", value: options.id, hidden_input: false) %><%= options.name %><br>
+                  <% end %>
+                  <br>
+                <% end %>
+              </div>
+              <% end %>
+
+              <!-- Buttons -->
+              <div class="modal-buttons">
+                  <!-- Left Button -->
+                  <button class="left-button"
+                          type="button"
+                          phx-click="left-button-click"
+                          phx-target={"#item-#{@id}"}>
+                    <div>
+                      <%= @left_button %>
+                    </div>
+                  </button>
+                  <!-- Right Button -->
+                  <button class="right-button"
+                          type="button"
+                          phx-click="right-button-click"
+                          phx-target={"#item-#{@id}"}>
+                    <div>
+                      <%= @right_button %>
+                    </div>
+                  </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/lunchbot_web/live/order_live.ex
+++ b/lib/lunchbot_web/live/order_live.ex
@@ -1,0 +1,124 @@
+defmodule LunchbotWeb.OrderLive do
+  use LunchbotWeb, :live_view
+
+  alias LunchbotWeb.Router.Helpers, as: Routes
+  alias Lunchbot.Repo
+  alias Lunchbot.LunchbotData
+
+  import Ecto.Query
+
+  def mount(_params, _session, socket) do
+    # How is this id going to be initialized?
+    todays_menu_id = 4
+
+    menu_data =
+      Repo.get(Lunchbot.LunchbotData.Menu, todays_menu_id)
+      |> Repo.preload(categories: [items: [option_headings: [:options]]])
+      |> Map.from_struct()
+
+    {:ok, assign(socket, menu_data: menu_data) |> assign(todays_menu_id: todays_menu_id)}
+  end
+
+  def handle_params(params, _url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  end
+
+  def apply_action(socket, :show, _params) do
+    assign(socket, show_modal: false)
+  end
+
+  def apply_action(%{assigns: %{show_modal: _}} = socket, :open_modal, params) do
+    assign(socket, show_modal: true, id: Integer.parse(params["id"]) |> elem(0))
+  end
+
+  def apply_action(socket, _live_action, _params) do
+    push_patch(socket,
+      to: Routes.create_order_path(socket, :show),
+      replace: true
+    )
+  end
+
+  def handle_event("open", %{"id" => id} = _args, socket) do
+    {:noreply,
+     push_patch(
+       assign(socket, show_modal: true),
+       to: Routes.create_order_modal_path(socket, :open_modal, id: id),
+       replace: true
+     )}
+  end
+
+  def handle_info(
+        {LunchbotWeb.LiveComponent.ModalLive, :button_clicked,
+         %{action: "submit", param: options}},
+        socket
+      ) do
+    option_ids_query =
+      from o in "options",
+        join: m in Lunchbot.LunchbotData.Menu,
+        on: m.id == ^socket.assigns.todays_menu_id,
+        where: o.name in ^options.selected_options,
+        select: o.id
+
+    option_ids = Repo.all(option_ids_query)
+
+    current_user_id = socket.assigns.current_user.id
+
+    # How is this id going to get set?
+    office_lunch_order_id = 1
+
+    order_id =
+      Repo.insert(%LunchbotData.Order{
+        user_id: current_user_id,
+        menu_id: socket.assigns.todays_menu_id,
+        lunch_order_id: office_lunch_order_id
+      })
+      |> case do
+        {:ok, %LunchbotData.Order{id: id}} ->
+          id
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+
+    order_item_id =
+      Repo.insert(%LunchbotData.OrderItem{
+        item_id: elem(Integer.parse(options.id), 0),
+        order_id: order_id
+      })
+      |> case do
+        {:ok, %LunchbotData.OrderItem{id: id}} ->
+          id
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+
+    for option_id <- option_ids do
+      LunchbotData.create_order_item_options(%{option_id: option_id, order_item_id: order_item_id})
+    end
+
+    socket =
+      socket
+      |> assign(show_modal: false)
+      |> assign(id: nil)
+
+    {:noreply, socket}
+  end
+
+  def handle_info(
+        {LunchbotWeb.LiveComponent.ModalLive, :button_clicked, %{action: "close"}},
+        socket
+      ) do
+    socket =
+      socket
+      |> assign(show_modal: false)
+      |> assign(id: nil)
+
+    {:noreply,
+     push_patch(
+       socket,
+       to: Routes.create_order_path(socket, :show),
+       replace: true
+     )}
+  end
+end

--- a/lib/lunchbot_web/live/order_live.html.heex
+++ b/lib/lunchbot_web/live/order_live.html.heex
@@ -1,0 +1,28 @@
+<div>
+  <%= for category <- @menu_data.categories do %>
+    <h1><%= category.name %></h1>
+    <%= for item <- category.items do %>
+      <button
+        phx-click="open"
+        phx-value-id={item.id}
+        type="button"
+        class="mr-8 btn btn-primary">
+        <%= item.name %>
+      </button>
+
+      <%= if assigns[:id] == item.id do %>
+      <.live_component
+        module={LunchbotWeb.LiveComponent.ModalLive}
+        id={"#{item.id}"}
+        title={"#{item.name}"}
+        body={item.option_headings}
+        right_button="Submit"
+        right_button_action="submit"
+        left_button="Cancel"
+        left_button_action="close")
+      >
+      </.live_component> 
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/lib/lunchbot_web/live/user_auth_live.ex
+++ b/lib/lunchbot_web/live/user_auth_live.ex
@@ -1,0 +1,17 @@
+defmodule LunchbotWeb.UserAuthLive do
+  import Phoenix.LiveView
+  alias Lunchbot.Accounts
+
+  # TODO:
+  #   https://blog.appsignal.com/2022/01/25/securing-your-phoenix-liveview-apps.html
+  #   & https://stackoverflow.com/questions/66217782/elixir-phoenix-liveview-passing-user-id-through-socket
+  def on_mount(:user, _params, %{"user_token" => user_token} = _session, socket) do
+    socket = assign(socket, :current_user, Accounts.get_user_by_session_token(user_token))
+
+    if socket.assigns.current_user do
+      {:cont, socket}
+    else
+      {:halt, redirect(socket, to: "/login")}
+    end
+  end
+end

--- a/lib/lunchbot_web/router.ex
+++ b/lib/lunchbot_web/router.ex
@@ -36,6 +36,15 @@ defmodule LunchbotWeb.Router do
   end
 
   scope "/", LunchbotWeb do
+    pipe_through [:browser, :require_authenticated_user]
+
+    live_session :user, on_mount: {LunchbotWeb.UserAuthLive, :user} do
+      live "/create_order", OrderLive, :show, as: :create_order
+      live "/create_order/modal", OrderLive, :open_modal, as: :create_order_modal
+    end
+  end
+
+  scope "/", LunchbotWeb do
     pipe_through :browser
 
     get "/", PageController, :index

--- a/lib/lunchbot_web/templates/page/index.html.heex
+++ b/lib/lunchbot_web/templates/page/index.html.heex
@@ -4,8 +4,17 @@
   <%= if assigns[:current_user] do %>
     <h2> Logged in as <%= @current_user.email %> </h2>
     <h2> Welcome <%= @current_user.name %>! </h2>
+    <font size="+2">
+      <center>
+          <strong>
+          <li>
+              <a href="/create_order">Create an order</a>
+          </li>
+          </strong>
+      </center>
+    </font>
     <%= if @current_user.role == "admin" do %>
-      <font size="+3">
+      <font size="+2">
         <center>
             <strong>
             <li>

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -15,7 +15,7 @@ alias Lunchbot.LunchbotData.Menu
 alias Lunchbot.LunchbotData.Category
 alias Lunchbot.LunchbotData.MenuCategories
 alias Lunchbot.LunchbotData.Item
-alias Lunchbot.LunchbotData.OptionHeadings
+alias Lunchbot.LunchbotData.OptionHeading
 alias Lunchbot.LunchbotData.Options
 alias Lunchbot.LunchbotData.ItemOptionHeadings
 
@@ -268,7 +268,7 @@ headings =
     %{name: "Dressing", priority: 2}
   ]
   |> Enum.each(fn hdg ->
-    Lunchbot.Repo.insert!(%OptionHeadings{name: hdg.name, priority: hdg.priority})
+    Lunchbot.Repo.insert!(%OptionHeading{name: hdg.name, priority: hdg.priority})
   end)
 
 heading_options = [
@@ -323,7 +323,7 @@ heading_options = [
 ]
 
 Enum.each(heading_options, fn hdg ->
-  heading = Lunchbot.Repo.get_by!(OptionHeadings, name: "#{hdg.name}")
+  heading = Lunchbot.Repo.get_by!(OptionHeading, name: "#{hdg.name}")
 
   Enum.each(hdg.option, fn option ->
     Lunchbot.Repo.insert!(%Options{
@@ -379,7 +379,7 @@ heading_items = [
 ]
 
 Enum.each(heading_items, fn hdg ->
-  heading = Lunchbot.Repo.get_by!(OptionHeadings, name: "#{hdg.name}")
+  heading = Lunchbot.Repo.get_by!(OptionHeading, name: "#{hdg.name}")
 
   Enum.each(hdg.items, fn item ->
     item = Lunchbot.Repo.get_by!(Item, name: "#{item.name}")

--- a/test/lunchbot/lunchbot_data_test.exs
+++ b/test/lunchbot/lunchbot_data_test.exs
@@ -909,7 +909,7 @@ defmodule Lunchbot.LunchbotDataTest do
     item_option_headings
   end
 
-  alias Lunchbot.LunchbotData.OptionHeadings
+  alias Lunchbot.LunchbotData.OptionHeading
 
   @valid_attrs %{name: "some name", priority: 42}
   @update_attrs %{name: "some updated name", priority: 43}
@@ -951,7 +951,7 @@ defmodule Lunchbot.LunchbotDataTest do
 
   describe "#create_option_headings/1" do
     test "with valid data creates a option_headings" do
-      assert {:ok, %OptionHeadings{} = option_headings} =
+      assert {:ok, %OptionHeading{} = option_headings} =
                LunchbotData.create_option_headings(@valid_attrs)
 
       assert option_headings.name == "some name"
@@ -970,7 +970,7 @@ defmodule Lunchbot.LunchbotDataTest do
       assert {:ok, option_headings} =
                LunchbotData.update_option_headings(option_headings, @update_attrs)
 
-      assert %OptionHeadings{} = option_headings
+      assert %OptionHeading{} = option_headings
       assert option_headings.name == "some updated name"
       assert option_headings.priority == 43
     end
@@ -988,7 +988,7 @@ defmodule Lunchbot.LunchbotDataTest do
   describe "#delete_option_headings/1" do
     test "deletes the option_headings" do
       option_headings = option_headings_fixture()
-      assert {:ok, %OptionHeadings{}} = LunchbotData.delete_option_headings(option_headings)
+      assert {:ok, %OptionHeading{}} = LunchbotData.delete_option_headings(option_headings)
 
       assert_raise Ecto.NoResultsError, fn ->
         LunchbotData.get_option_headings!(option_headings.id)


### PR DESCRIPTION
There are still a couple of components to truly fill out a user creating an order, but with the boilerplate here right now we should be able to reasonably move forward.

Here's what I have so far:

Slackbot will likely have a generic link which directs users from the Slack channels to `/create_order` or maybe `/create_order/:office` depending on whether we are in the PVD or BLDR channels. From the front page after login, we see: 

<img width="580" alt="Screen Shot 2022-07-26 at 2 38 45 PM" src="https://user-images.githubusercontent.com/69921727/181107611-a2432c2f-01bf-4566-877d-9f8825da82e0.png">

I made a makeshift menu with options for each item. The UI is pretty basic right now, but essentially each item is a button which pops up a modal with all of the option headings and options.

<img width="691" alt="Screen Shot 2022-07-26 at 2 40 29 PM" src="https://user-images.githubusercontent.com/69921727/181107885-043f7f01-53dc-474c-aa23-91e33fe4c680.png">

Excuse the poor design for right now! As we bring in the new CSS from the format @cbarber bought, this will hopefully look a lot better

<img width="700" alt="Screen Shot 2022-07-28 at 11 00 33 AM" src="https://user-images.githubusercontent.com/69921727/181595668-42773d6f-404b-40a8-8be5-45f69f13e27f.png">

<img width="677" alt="Screen Shot 2022-07-28 at 11 00 39 AM" src="https://user-images.githubusercontent.com/69921727/181595684-410b5177-543a-4123-8d08-dec48bb34dbb.png">

Right now, we are submitting an item and considering that to be the entirety of the user's order. So, when we hit submit, we see the updates in our terminal:

<img width="1219" alt="Screen Shot 2022-07-28 at 10 53 53 AM" src="https://user-images.githubusercontent.com/69921727/181595957-cf9bac18-661f-4583-9933-874add4d49da.png">

In the future, once we have a working shopping cart live component, we will be able to add some sort of "update" and "remove" functionalities so that the user could update their order with more items or remove items that they don't want in their order. This will also have to come with a "submit current order" which would finalize their order. The prices are also not here yet since my items table currently doesn't have a price column, so I held off on that. Also, it looks like #27 has queries related to this that we will be able to use in the near future.
