### PR TITLE
Shared Cart

### DIFF
--- a/lib/lunchbot/lunchbot_data.ex
+++ b/lib/lunchbot/lunchbot_data.ex
@@ -881,6 +881,7 @@ defmodule Lunchbot.LunchbotData do
     %OrderItem{}
     |> OrderItem.changeset(attrs)
     |> Repo.insert()
+    |> OrderItem.notify_subscribers([:order_item, :created])
   end
 
   @doc """
@@ -899,6 +900,7 @@ defmodule Lunchbot.LunchbotData do
     order_item
     |> OrderItem.changeset(attrs)
     |> Repo.update()
+    |> OrderItem.notify_subscribers([:order_item, :updated])
   end
 
   @doc """
@@ -915,6 +917,7 @@ defmodule Lunchbot.LunchbotData do
   """
   def delete_order_item(%OrderItem{} = order_item) do
     Repo.delete(order_item)
+    |> OrderItem.notify_subscribers([:order_item, :deleted])
   end
 
   @doc """

--- a/lib/lunchbot/lunchbot_data/office.ex
+++ b/lib/lunchbot/lunchbot_data/office.ex
@@ -6,6 +6,7 @@ defmodule Lunchbot.LunchbotData.Office do
     field :timezone, :string
     field :name, :string
     field :slack_channel_name, :string
+    has_many :office_lunch_orders, Lunchbot.LunchbotData.OfficeLunchOrder
 
     timestamps()
   end

--- a/lib/lunchbot/lunchbot_data/office_lunch_order.ex
+++ b/lib/lunchbot/lunchbot_data/office_lunch_order.ex
@@ -4,8 +4,9 @@ defmodule Lunchbot.LunchbotData.OfficeLunchOrder do
 
   schema "office_lunch_orders" do
     field :day, :date
-    field :office_id, :integer
     field :menu_id, :integer
+    belongs_to :office, Lunchbot.LunchbotData.Office
+    has_many :orders, Lunchbot.LunchbotData.Order, foreign_key: :lunch_order_id
 
     timestamps()
   end

--- a/lib/lunchbot/lunchbot_data/order.ex
+++ b/lib/lunchbot/lunchbot_data/order.ex
@@ -22,7 +22,13 @@ defmodule Lunchbot.LunchbotData.Order do
 
   def get_total(%Lunchbot.LunchbotData.Order{} = order) do
     # total price of an Order the the price of all the items in the order.
-    Enum.map(order.order_items, &Lunchbot.LunchbotData.OrderItem.get_total/1)
-    |> Enum.sum()
+    list_order_totals = Enum.map(order.order_items, &Lunchbot.LunchbotData.OrderItem.get_total/1)
+
+    # check for nil values, return nil if found
+    if Enum.member?(list_order_totals, nil) do
+      nil
+    else
+      list_order_totals |> Enum.sum()
+    end
   end
 end

--- a/lib/lunchbot/lunchbot_data/order_item.ex
+++ b/lib/lunchbot/lunchbot_data/order_item.ex
@@ -18,11 +18,15 @@ defmodule Lunchbot.LunchbotData.OrderItem do
   end
 
   def get_total(%Lunchbot.LunchbotData.OrderItem{} = order_item) do
-    total_options_price =
-      Enum.map(order_item.order_item_options, &Lunchbot.LunchbotData.OrderItemOptions.get_total/1)
-      |> Enum.sum()
-
     # the total price of an OrderItem is the price of it's Options + the Item itself
-    total_options_price + order_item.item.price
+    list_total_options_prices =
+      Enum.map(order_item.order_item_options, &Lunchbot.LunchbotData.OrderItemOptions.get_total/1)
+
+    if Enum.member?(list_total_options_prices, nil) ||
+         is_nil(order_item.item.price) do
+      nil
+    else
+      Enum.sum(list_total_options_prices) + order_item.item.price
+    end
   end
 end

--- a/lib/lunchbot/lunchbot_data/order_item_options.ex
+++ b/lib/lunchbot/lunchbot_data/order_item_options.ex
@@ -20,9 +20,17 @@ defmodule Lunchbot.LunchbotData.OrderItemOptions do
   def get_total(%Lunchbot.LunchbotData.OrderItemOptions{} = order_item_option) do
     # the total price of an OrderItemOption is the price the option + included extras
     if order_item_option.option.extras do
-      order_item_option.option.extra_price + order_item_option.option.price
+      if is_nil(order_item_option.option.extra_price) || is_nil(order_item_option.option.price) do
+        nil
+      else
+        order_item_option.option.extra_price + order_item_option.option.price
+      end
     else
-      order_item_option.option.price
+      if is_nil(order_item_option.option.price) do
+        nil
+      else
+        order_item_option.option.price
+      end
     end
   end
 end

--- a/lib/lunchbot_web/controllers/shared_cart/office_selector.ex
+++ b/lib/lunchbot_web/controllers/shared_cart/office_selector.ex
@@ -1,0 +1,12 @@
+defmodule LunchbotWeb.SharedCart.OfficeSelector do
+  defstruct [:office_id]
+  @types %{office_id: :integer}
+
+  import Ecto.Changeset
+
+  def changeset(%__MODULE__{} = office, attrs) do
+    {office, @types}
+    |> cast(attrs, Map.keys(@types))
+    |> validate_required([:office_id])
+  end
+end

--- a/lib/lunchbot_web/controllers/shared_cart/office_selector_interface_context.ex
+++ b/lib/lunchbot_web/controllers/shared_cart/office_selector_interface_context.ex
@@ -1,0 +1,7 @@
+defmodule LunchbotWeb.SharedCart.OfficeSelectorInterfaceContext do
+  alias LunchbotWeb.SharedCart.OfficeSelector
+
+  def change_office(%OfficeSelector{} = user, attrs \\ %{}) do
+    OfficeSelector.changeset(user, attrs)
+  end
+end

--- a/lib/lunchbot_web/controllers/shared_cart/shared_cart_controller.ex
+++ b/lib/lunchbot_web/controllers/shared_cart/shared_cart_controller.ex
@@ -1,0 +1,24 @@
+defmodule LunchbotWeb.SharedCart.SharedCartController do
+  import Ecto.Query
+
+  def get_lunch_order_for_office(office_id \\ 1, date \\ Date.utc_today()) do
+    filter_lunch_orders_to_today_and_onwards =
+      from(o in Lunchbot.LunchbotData.OfficeLunchOrder, where: o.day >= ^date)
+
+    lunch_orders =
+      Lunchbot.Repo.get_by(Lunchbot.LunchbotData.Office, id: office_id)
+      |> Lunchbot.Repo.preload(
+        office_lunch_orders:
+          {filter_lunch_orders_to_today_and_onwards,
+           [
+             orders: [:menu, order_items: [:item, order_item_options: [:option]]]
+           ]}
+      )
+
+    if is_nil(Enum.at(lunch_orders.office_lunch_orders, 0)) do
+      nil
+    else
+      Enum.at(lunch_orders.office_lunch_orders, 0).orders
+    end
+  end
+end

--- a/lib/lunchbot_web/live/components/order_component.ex
+++ b/lib/lunchbot_web/live/components/order_component.ex
@@ -1,0 +1,32 @@
+defmodule LunchbotWeb.OrderComponent do
+  @moduledoc false
+
+  use Phoenix.Component
+
+  alias Lunchbot.LunchbotData.OrderItem
+
+  # Visual representation of an "Order".
+  # Required field:
+  #   order = Lunchbot.LunchbotData.Order
+  def display_order(assigns) do
+    ~H"""
+    <div>
+      From <b><%= assigns.order.menu.name %></b> @ <em><%= assigns.order.inserted_at %></em>
+      <ul>
+        <%= for order_item <- assigns.order.order_items do %>
+            <li><%= order_item.item.name %>
+              <%= if !Enum.empty?(order_item.order_item_options) do %>
+                (
+                <%= for order_item_option <- order_item.order_item_options do %>
+                  <%= order_item_option.option.name %>
+                <% end %>
+                )
+              <% end %>
+              for <em>$<%= OrderItem.get_total(order_item) %></em>
+            </li>
+        <% end %>
+      </ul>
+    </div>
+    """
+  end
+end

--- a/lib/lunchbot_web/live/components/order_component.ex
+++ b/lib/lunchbot_web/live/components/order_component.ex
@@ -22,7 +22,9 @@ defmodule LunchbotWeb.OrderComponent do
                 <% end %>
                 )
               <% end %>
-              for <em>$<%= OrderItem.get_total(order_item) %></em>
+              <%= if !is_nil(OrderItem.get_total(order_item)) do %>
+                for <em>$<%= OrderItem.get_total(order_item) %></em>
+              <% end %>
             </li>
         <% end %>
       </ul>

--- a/lib/lunchbot_web/live/previous_orders_live.ex
+++ b/lib/lunchbot_web/live/previous_orders_live.ex
@@ -24,23 +24,7 @@ defmodule LunchbotWeb.PreviousOrdersLive do
     <%= for an_order <- @user.orders do %>
       <li>ORDER # <%= an_order.id %> || $<%= Order.get_total(an_order) %>
         <ul>
-          <li>From the <%= an_order.menu.name %> Menu</li>
-          <li>Date Ordered: <%= an_order.inserted_at %></li>
-          <li>Items in order:
-            <ul>
-              <%= for an_order_item <- an_order.order_items do %>
-                  <li><%= an_order_item.item.name %>
-                    <%= if !Enum.empty?(an_order_item.order_item_options) do %>
-                      (w/ options:
-                      <%= for an_order_item_option <- an_order_item.order_item_options do %>
-                        <%= an_order_item_option.option.name %>
-                      <% end %>
-                      )
-                    <% end %>
-                  </li>
-              <% end %>
-            </ul>
-          </li>
+          <LunchbotWeb.OrderComponent.display_order order={an_order} />
         </ul>
       </li>
     <% end %>

--- a/lib/lunchbot_web/live/shared_cart.ex
+++ b/lib/lunchbot_web/live/shared_cart.ex
@@ -1,0 +1,59 @@
+defmodule LunchbotWeb.SharedCart do
+  @moduledoc false
+
+  use LunchbotWeb, :live_view
+
+  import LunchbotWeb.SharedCart.SharedCartController
+  alias LunchbotWeb.SharedCart.OfficeSelector
+  alias LunchbotWeb.SharedCart.OfficeSelectorInterfaceContext
+  alias Lunchbot.LunchbotData
+
+  def mount(_params, _session, socket) do
+    if connected?(socket), do: Lunchbot.LunchbotData.OrderItem.subscribe()
+
+    default_office_id = 1
+
+    {:ok,
+     assign(socket,
+       office_lunch_orders: get_lunch_order_for_office(default_office_id),
+       offices: LunchbotData.list_offices(),
+       selected_office_id: default_office_id
+     )
+     |> assign_office()
+     |> assign_changeset()}
+  end
+
+  def assign_office(socket) do
+    socket
+    |> assign(:office_selector, %OfficeSelector{})
+  end
+
+  def assign_changeset(%{assigns: %{office_selector: office_selector}} = socket) do
+    socket
+    |> assign(:changeset, OfficeSelectorInterfaceContext.change_office(office_selector))
+  end
+
+  # Refetch currently displayed order data, assign to socket watched by this LiveView
+  defp fetch(socket) do
+    office_lunch_orders = get_lunch_order_for_office(socket.assigns.selected_office_id)
+
+    offices = LunchbotData.list_offices()
+
+    assign(socket, office_lunch_orders: office_lunch_orders, offices: offices)
+  end
+
+  # listens to the notifications broadcast by OrderItems
+  # fetches a fresh listing of office lunch orders from the database
+  def handle_info({Lunchbot.LunchbotData.OrderItem, [:order_item, _], _}, socket) do
+    {:noreply, fetch(socket)}
+  end
+
+  # handles office changes
+  def handle_event("change-office", %{"office_selector" => selector_params}, socket) do
+    {:noreply,
+     assign(socket,
+       office_lunch_orders: get_lunch_order_for_office(selector_params["office_selection"]),
+       selected_office_id: selector_params["office_selection"]
+     )}
+  end
+end

--- a/lib/lunchbot_web/live/shared_cart.html.heex
+++ b/lib/lunchbot_web/live/shared_cart.html.heex
@@ -1,0 +1,16 @@
+<div id="shared-cart">
+
+  <div>
+    <.form let={f} for={@changeset} id="shared-cart-dropdown-form" phx-change="change-office">
+        <%= label f, :office_selection %>
+        <%= Phoenix.HTML.Form.select f, :office_selection, Enum.map(@offices, &{&1.name, &1.id}), selected: @selected_office_id%>
+    </.form>
+  </div>
+
+  <h2>Shared Cart</h2>
+  <%= if @office_lunch_orders do %>
+    <%= for order <- @office_lunch_orders do %>
+      <LunchbotWeb.OrderComponent.display_order order={order} />
+    <% end %>
+  <% end %>
+</div>

--- a/lib/lunchbot_web/router.ex
+++ b/lib/lunchbot_web/router.ex
@@ -46,6 +46,7 @@ defmodule LunchbotWeb.Router do
     end
 
     live "/list-orders", PreviousOrdersLive
+    live "/shared-cart", SharedCart
   end
 
   scope "/", LunchbotWeb do

--- a/mix.exs
+++ b/mix.exs
@@ -56,7 +56,8 @@ defmodule Lunchbot.MixProject do
       {:plug_cowboy, "~> 2.5"},
       {:elixir_auth_google, "~> 1.6.3"},
       {:dotenv, "~> 3.0.0", only: [:dev, :test]},
-      {:mox, "~> 1.0", only: :test}
+      {:mox, "~> 1.0", only: :test},
+      {:phoenix_pubsub, "~> 2.0"}
     ]
   end
 

--- a/test/lunchbot/order_test.exs
+++ b/test/lunchbot/order_test.exs
@@ -39,6 +39,19 @@ defmodule Lunchbot.OrderTest do
 
       assert Order.get_total(order) == 66
     end
+
+    test "order with singular PRICELESS item" do
+      order = %Order{
+        order_items: [
+          %OrderItem{
+            item: %Item{},
+            order_item_options: []
+          }
+        ]
+      }
+
+      assert Order.get_total(order) == nil
+    end
   end
 
   describe "#OrderItem.get_total/1" do
@@ -100,6 +113,24 @@ defmodule Lunchbot.OrderTest do
 
       assert OrderItem.get_total(order_item) == 110
     end
+
+    test "single PRICELESS order_item_options" do
+      order_item = %OrderItem{
+        item: %Item{
+          price: 10
+        },
+        order_item_options: [
+          %OrderItemOptions{
+            option: %Options{
+              extras: false,
+              price: nil
+            }
+          }
+        ]
+      }
+
+      assert OrderItem.get_total(order_item) == nil
+    end
   end
 
   describe "#OrderItemOptions.get_total/1" do
@@ -124,6 +155,18 @@ defmodule Lunchbot.OrderTest do
       }
 
       assert OrderItemOptions.get_total(order_item_option) == 33
+    end
+
+    test "order item option with PRICELESS extras" do
+      order_item_option = %OrderItemOptions{
+        option: %Options{
+          extra_price: nil,
+          extras: true,
+          price: nil
+        }
+      }
+
+      assert OrderItemOptions.get_total(order_item_option) == nil
     end
   end
 end


### PR DESCRIPTION
Auto-updating Shared Cart component.

Had originally created this as a LiveComponent, but as they are not allotted the same methods and functionality of a LiveComponent (namely, cannot properly subscribe to DB events) it had to be converted. 
### Usage
* Instead of using the shared cart as a component, it should instead be inserted into existing LiveViews via [`Phoenix.LiveView.Helpers.live_render/3`](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.Helpers.html#live_render/3). It will operate independently of the parent LiveView, and doesn't need any data passed to it.

<img width="398" alt="image" src="https://user-images.githubusercontent.com/45409688/182458458-a0ecbf70-2b7c-4870-b32b-43bb9310bd30.png">



### Future Considerations
* Any time a change is made to an order outside of the `LunchbotData` methods for OrderItems, `OrderItem.notify_subscribers/2` must be invoked. This means that any workflow that creates an order must also go through the proper paths when creating the order item. Invocations directly accessing the DB with `Repo.Insert / Repo.*` w/o the `notify_subscribers/2` will not publish any changes to subscribers

## Quick Demo of PubSub updating

https://user-images.githubusercontent.com/45409688/182892044-f506042a-7f3a-4260-95b0-ee208e606457.mov
