### PR TITLE
feat: Office dropdown on /create_order

### DIFF
--- a/lib/lunchbot/lunchbot_data.ex
+++ b/lib/lunchbot/lunchbot_data.ex
@@ -243,8 +243,8 @@ defmodule Lunchbot.LunchbotData do
   """
   def get_menu!(id), do: Repo.get!(Menu, id)
 
-  def get_all_menu_data!(id) do
-    Repo.get!(Menu, id)
+  def get_all_menu_data(id) do
+    Repo.get(Menu, id)
     |> Repo.preload(categories: [items: [option_headings: [:options]]])
     |> Map.from_struct()
   end

--- a/lib/lunchbot_web/live/order_live.html.heex
+++ b/lib/lunchbot_web/live/order_live.html.heex
@@ -22,11 +22,17 @@
             left_button="Cancel"
             left_button_action="close")
           >
-          </.live_component> 
+          </.live_component>
         <% end %>
       <% end %>
     <% end %>
   <% else %>
-    <h1>No given menu currently.</h1>
+    <%= if assigns[:office_id] do %>
+      <h1>No given menu for this office currently.</h1>
+    <% else %>
+    <%= f = form_for :office_id, "#", phx_change: "office_select" %>
+        <%= label f, "Select an office" %>
+        <%= select f, :office, [{"Please select...", 0}] ++ Enum.map(@offices, &{&1.name, &1.id}), required: true %>
+    <% end %>
   <% end %>
 </div>


### PR DESCRIPTION
On `/create_order`, there is now a dropdown which allows you to pick which office you want to order for. This dropdown sets the `office_id`, and then queries for a menu.

<img width="500" alt="Screen Shot 2022-08-03 at 1 50 32 PM" src="https://user-images.githubusercontent.com/69921727/182696655-f820ba8d-e4c9-44ac-9169-203003fade71.png">

 If there is no menu data, then it will show: 

<img width="500" alt="Screen Shot 2022-08-03 at 1 51 20 PM" src="https://user-images.githubusercontent.com/69921727/182696785-f1d0178e-a7ca-4807-b65f-a318a1499845.png">

