### PR TITLE
Rating Previous Orders

### DIFF
--- a/README_Lunchbot.md
+++ b/README_Lunchbot.md
@@ -43,6 +43,7 @@ Below is the database model for Lunchbot displayed using mermaid.js. You can mod
         int id
         int order_id FK
         int item_id FK
+        int rating
     }
     ITEMS {
       int id

--- a/lib/lunchbot/lunchbot_data/item.ex
+++ b/lib/lunchbot/lunchbot_data/item.ex
@@ -1,6 +1,10 @@
 defmodule Lunchbot.LunchbotData.Item do
   use Ecto.Schema
+
   import Ecto.Changeset
+  import Ecto.Query
+
+  alias Lunchbot.Repo
 
   schema "items" do
     belongs_to :category, Lunchbot.LunchbotData.Category
@@ -23,5 +27,14 @@ defmodule Lunchbot.LunchbotData.Item do
     item
     |> cast(attrs, [:name, :description, :price, :category_id, :image_url, :item_image, :deleted])
     |> validate_required([:name, :price, :category_id])
+  end
+
+  def get_rating(item_id) do
+    query =
+      from o in "order_items",
+        where: o.item_id == ^item_id,
+        select: avg(o.rating)
+
+    Repo.all(query) |> Enum.at(0) |> Decimal.round(1)
   end
 end

--- a/lib/lunchbot/lunchbot_data/order_item.ex
+++ b/lib/lunchbot/lunchbot_data/order_item.ex
@@ -6,6 +6,7 @@ defmodule Lunchbot.LunchbotData.OrderItem do
     belongs_to :item, Lunchbot.LunchbotData.Item
     field :order_id, :integer
     has_many :order_item_options, Lunchbot.LunchbotData.OrderItemOptions
+    field :rating, :integer
 
     timestamps()
   end
@@ -13,7 +14,7 @@ defmodule Lunchbot.LunchbotData.OrderItem do
   @doc false
   def changeset(order_item, attrs) do
     order_item
-    |> cast(attrs, [:order_id, :item_id])
+    |> cast(attrs, [:order_id, :item_id, :rating])
     |> validate_required([:order_id, :item_id])
   end
 

--- a/lib/lunchbot_web/live/previous_orders_live.ex
+++ b/lib/lunchbot_web/live/previous_orders_live.ex
@@ -1,10 +1,13 @@
 defmodule LunchbotWeb.PreviousOrdersLive do
   @moduledoc false
   use Phoenix.LiveView, layout: {LunchbotWeb.LayoutView, "live.html"}
+  #  use LunchbotWeb, :view
 
   import Lunchbot.Repo
+  import Phoenix.HTML.Link
   alias Lunchbot.Accounts
   alias Lunchbot.LunchbotData.Order
+  alias Lunchbot.LunchbotData.OrderItem
 
   # Initial state for the live view; populates the relevant socket assignments
   def mount(_params, session, socket) do
@@ -14,7 +17,17 @@ defmodule LunchbotWeb.PreviousOrdersLive do
       Accounts.get_user_by_session_token(user_token)
       |> preload(orders: [:menu, order_items: [:item, order_item_options: [:option]]])
 
-    {:ok, assign(socket, user: user_with_preloaded_orders)}
+    {:ok,
+     assign(socket,
+       user: user_with_preloaded_orders,
+       show_rating: true,
+       show_rating_modifiers: true
+     )}
+  end
+
+  def handle_event("rating-edit", %{"myvar1" => "@order_item", "myvar2" => "val2"}, socket) do
+    IO.inspect("TODO - HANDLE rating-edit EVENT")
+    {:noreply, socket}
   end
 
   def render(assigns) do
@@ -24,7 +37,37 @@ defmodule LunchbotWeb.PreviousOrdersLive do
     <%= for an_order <- @user.orders do %>
       <li>ORDER # <%= an_order.id %> || $<%= Order.get_total(an_order) %>
         <ul>
-          <LunchbotWeb.OrderComponent.display_order order={an_order} />
+          <div>
+            From <b><%= an_order.menu.name %></b> @ <em><%= an_order.inserted_at %></em>
+            <ul>
+              <%= for order_item <- an_order.order_items do %>
+                  <li><%= order_item.item.name %>
+                    <%= if !Enum.empty?(order_item.order_item_options) do %>
+                      (
+                      <%= for order_item_option <- order_item.order_item_options do %>
+                        <%= order_item_option.option.name %>
+                      <% end %>
+                      )
+                    <% end %>
+                    <%= if !is_nil(OrderItem.get_total(order_item)) do %>
+                      for <em>$<%= OrderItem.get_total(order_item) %></em>
+                    <% end %>
+                    <%= if Map.has_key?(assigns, :show_rating) do %>
+                      <%= if !is_nil(order_item.rating) do %>
+                        [Rating: <%= order_item.rating %>/5]
+                        <%= if Map.has_key?(assigns, :show_rating_modifiers) do %>
+                          (<span phx-click="rating-edit" phx-value-myvar1="@order_item" phx-value-myvar2="val2"><a>Edit Rating</a></span>)
+                        <% end %>
+                      <% else %>
+                        <%= if Map.has_key?(assigns, :show_rating_modifiers) do %>
+                          (<%= link "Add Rating", to: "#TODO-ADD-RATING" %>)
+                        <% end %>
+                      <% end %>
+                    <% end %>
+                  </li>
+              <% end %>
+            </ul>
+          </div>
         </ul>
       </li>
     <% end %>

--- a/lib/lunchbot_web/templates/admin/order_item/form.html.heex
+++ b/lib/lunchbot_web/templates/admin/order_item/form.html.heex
@@ -22,6 +22,14 @@
         <%= error_tag f, :item_id %>
       </div>
     </div>
+
+    <div class="torch-form-group">
+      <%= label f, :rating %>
+      <div class="torch-form-group-input">
+        <%= number_input f, :rating %>
+        <%= error_tag f, :rating %>
+      </div>
+    </div>
   
     <div class="torch-submit-form">
       <%= submit "Submit", class: "torch-submit-button" %>

--- a/lib/lunchbot_web/templates/admin/order_item/index.html.heex
+++ b/lib/lunchbot_web/templates/admin/order_item/index.html.heex
@@ -23,6 +23,12 @@
             <%= number_filter_select(:order_item, :item_id, @conn.params) %>
             <%= filter_number_input(:order_item, :item_id, @conn.params) %>
           </div>
+
+          <div class="field">
+            <label>Rating</label>
+            <%= number_filter_select(:order_item, :rating, @conn.params) %>
+            <%= filter_number_input(:order_item, :rating, @conn.params) %>
+          </div>
         
         <button type="submit" class="torch-button">Search</button>
         <%= link "Clear Filters", to: Routes.admin_order_item_path(@conn, :index) %>
@@ -39,6 +45,8 @@
               <th><%= table_link(@conn, "Order", :order_id) %></th>
             
               <th><%= table_link(@conn, "Item", :item_id) %></th>
+
+              <th><%= table_link(@conn, "Rating", :rating) %></th>
             
             <th><span>Actions</span></th>
           </tr>
@@ -50,6 +58,8 @@
                 <td><%= order_item.order_id %></td>
               
                 <td><%= order_item.item_id %></td>
+
+                <td><%= order_item.rating %></td>
               
               <td class="torch-actions">
                 <span><%= link "Show", to: Routes.admin_order_item_path(@conn, :show, order_item) %></span>

--- a/lib/lunchbot_web/templates/admin/order_item/show.html.heex
+++ b/lib/lunchbot_web/templates/admin/order_item/show.html.heex
@@ -21,6 +21,11 @@
           <div class="torch-show-label">Item:</div>
           <div class="torch-show-data"><%= @order_item.item_id %></div>
         </div>
+
+        <div class="torch-show-attribute">
+          <div class="torch-show-label">Rating:</div>
+          <div class="torch-show-data"><%= @order_item.rating %></div>
+        </div>
       
     </section>
   </div>

--- a/priv/repo/migrations/20220808164936_add_rating_col_to_order_item.exs
+++ b/priv/repo/migrations/20220808164936_add_rating_col_to_order_item.exs
@@ -1,0 +1,9 @@
+defmodule Lunchbot.Repo.Migrations.AddRatingColToOrderItem do
+  use Ecto.Migration
+
+  def change do
+    alter table(:order_items) do
+      add :rating, :integer
+    end
+  end
+end


### PR DESCRIPTION
**_Not going to have time to finish this feature, so this is some quick notes for whomever picks it up next._**
### Current Implementation Notes
* Allow users to rate and edit ratings in the previous orders page. Can add to others in next feature.
* an `ORDER_ITEM` has a rating, not an `ITEM`. Items get their [abstracted] ratings _through the average_ of order items.
* A user can rate each individual item in their order NOT the order as a whole. By association, this will store the rating for the SPECIFIC order item (options, extras, and all) as well.

### Quick TODO Notes
* Should use `Lunchbot.LunchbotData.update_order_item/2` when adding and editing ratings. Note that LiveView has [handy features](https://hexdocs.pm/phoenix_live_view/form-bindings.html) for dealing with changesets with this sort of data which should be used for editing ratings.

* ~~UI-wise; Probably shouldn't use the order component for this as the events are starting to get complex and clogging up the component which is used elsewhere. Should pull order component code back into the previous orders view~~ and maybe consider a rating component? **Done**

* Would be simpler to redirect to a new route with `:edit` `:create` `:delete` methods, but would be a lot better on the user to keep the rating system all on the previous orders page. I was thinking when you click add rating, just replace that text with a set of five stars (though for testing just "1 2 3 4 5") each with an event handler, that will assign that star value [Might have to be in a modal of some sort instead of in-line, as I'm unsure how to update template text]. The page would then auto-update due to order_items subscription.