### PR TITLE
Pt/ecto association bug

### DIFF
--- a/lib/lunchbot/lunchbot_data.ex
+++ b/lib/lunchbot/lunchbot_data.ex
@@ -88,6 +88,11 @@ defmodule Lunchbot.LunchbotData do
     Repo.all(Office)
   end
 
+  def list_office_name_id_tuples do
+    Repo.all(Office)
+    |> Enum.map(&{&1.name, &1.id})
+  end
+
   @doc """
   Gets a single office.
 

--- a/lib/lunchbot_web/controllers/admin/select_menu_controller.ex
+++ b/lib/lunchbot_web/controllers/admin/select_menu_controller.ex
@@ -8,8 +8,9 @@ defmodule LunchbotWeb.Admin.SelectMenuController do
     changeset = OfficeLunchOrder.changeset(%OfficeLunchOrder{}, %{})
 
     menus = LunchbotData.list_menu_name_id_tuples()
+    offices = LunchbotData.list_office_name_id_tuples()
 
-    render(conn, "view.html", changeset: changeset, menus: menus)
+    render(conn, "view.html", changeset: changeset, menus: menus, offices: offices)
   end
 
   def create(conn, %{"office_lunch_order" => olo_params}) do

--- a/lib/lunchbot_web/controllers/admin/select_menu_controller.ex
+++ b/lib/lunchbot_web/controllers/admin/select_menu_controller.ex
@@ -32,8 +32,8 @@ defmodule LunchbotWeb.Admin.SelectMenuController do
 
     new_office_lunch_order = %{
       day: formatted_date,
-      office_id: Integer.parse(olo_params["office"]) |> elem(0),
-      menu_id: Integer.parse(olo_params["menu"]) |> elem(0)
+      office_id: olo_params["office_id"],
+      menu_id: olo_params["menu_id"]
     }
 
     case LunchbotData.create_office_lunch_order(new_office_lunch_order) do

--- a/lib/lunchbot_web/templates/admin/select_menu/view.html.heex
+++ b/lib/lunchbot_web/templates/admin/select_menu/view.html.heex
@@ -8,7 +8,7 @@
     <% end %>
 
     <%= label f, :office_id, "Office" %>
-    <%= select f, :office_id, ["Providence": 1, "Boulder": 2], required: true %>
+    <%= select f, :office_id, @offices, required: true %>
     <%= error_tag f, :office_id %>
 
     <%= label f, :menu_id, "Menu"%>

--- a/lib/lunchbot_web/templates/admin/select_menu/view.html.heex
+++ b/lib/lunchbot_web/templates/admin/select_menu/view.html.heex
@@ -7,13 +7,13 @@
         </div>
     <% end %>
 
-    <%= label f, :office %>
-    <%= select f, :office, ["Providence": 1, "Boulder": 2], required: true %>
-    <%= error_tag f, :office %>
+    <%= label f, :office_id, "Office" %>
+    <%= select f, :office_id, ["Providence": 1, "Boulder": 2], required: true %>
+    <%= error_tag f, :office_id %>
 
-    <%= label f, :menu %>
-    <%= select f, :menu,  @menus, required: true %>
-    <%= error_tag f, :menu %>
+    <%= label f, :menu_id, "Menu"%>
+    <%= select f, :menu_id,  @menus, required: true %>
+    <%= error_tag f, :menu_id %>
 
     <%= label f, :date %>
     <%= date_select f, :date, year: [options: 2022..2050], required: true %>


### PR DESCRIPTION
fixed ecto association bug where 'office' was not loaded when an admin goes to select a menu. The parameters from the office_lunch_order now matches with the attributes that were defined in the changeset. I also changed the hard coded list of offices in the <select> tag to be dynamic to handle possible database updates. 