### PR TITLE
Pt/export orders bug

### DIFF
--- a/lib/lunchbot/lunchbot_data.ex
+++ b/lib/lunchbot/lunchbot_data.ex
@@ -569,7 +569,7 @@ defmodule Lunchbot.LunchbotData do
       |> Repo.all()
       |> Enum.at(0)
 
-    if !is_nil(lunch_order_id) do
+    if lunch_order_id do
       from(o in Order,
         where: o.lunch_order_id == ^lunch_order_id,
         preload: [

--- a/lib/lunchbot/lunchbot_data.ex
+++ b/lib/lunchbot/lunchbot_data.ex
@@ -586,44 +586,41 @@ defmodule Lunchbot.LunchbotData do
     end
   end
 
-  def format_orders(order_struct) do
-    if !is_nil(order_struct) do
-      orders =
-        for order <- order_struct do
-          timestamp = order.inserted_at
-          user = order.user
+  def format_orders(order_struct = [%Order{} | _]) do
+    for order <- order_struct do
+      timestamp = order.inserted_at
+      user = order.user
 
-          order_items =
-            for order_item <- order.order_items do
-              item_with_options =
-                for order_item_option <- order_item.options do
-                  order_item_option
-                end
-                |> Enum.join(", ")
-
-              if String.length(item_with_options) > 0 do
-                order_item.item <>
-                  " w/ options: " <>
-                  item_with_options
-              else
-                order_item.item
-              end
+      order_items =
+        for order_item <- order.order_items do
+          item_with_options =
+            for order_item_option <- order_item.options do
+              order_item_option
             end
+            |> Enum.join(", ")
 
-          [
-            timestamp,
-            user,
-            for item <- order_items do
-              item
-            end
-          ]
-          |> List.flatten()
+          if String.length(item_with_options) > 0 do
+            order_item.item <>
+              " w/ options: " <>
+              item_with_options
+          else
+            order_item.item
+          end
         end
 
-      orders
-    else
-      nil
+      [
+        timestamp,
+        user,
+        for item <- order_items do
+          item
+        end
+      ]
+      |> List.flatten()
     end
+  end
+
+  def format_orders(_) do
+    nil
   end
 
   @doc """

--- a/lib/lunchbot_web/controllers/admin/export_orders_controller.ex
+++ b/lib/lunchbot_web/controllers/admin/export_orders_controller.ex
@@ -6,7 +6,7 @@ defmodule LunchbotWeb.Admin.ExportOrdersController do
   def index(conn, _params) do
     orders = LunchbotData.format_orders(LunchbotData.list_preloaded_orders())
 
-    if !is_nil(orders) do
+    if orders do
       list_orders =
         Enum.map(orders, fn x ->
           x |> Enum.map(fn g -> g |> to_string() end) |> Enum.join(", ")

--- a/lib/lunchbot_web/templates/admin/export_orders/index.html.heex
+++ b/lib/lunchbot_web/templates/admin/export_orders/index.html.heex
@@ -1,4 +1,4 @@
-<%= if !is_nil(@orders) do %>
+<%= if @orders do %>
 <h1>Orders to be exported</h1>
 <ul>
 <%= for order <- @orders do %>


### PR DESCRIPTION
I noticed that when there is an office lunch order created but there aren't any orders placed, the display for export_orders is incorrect. It should say "No orders to export" rather than "Orders to be exported" with nothing underneath. With this fix, I also refactored out unnecessary is_nil branches. 