### PR TITLE
Pt/select menu live

### DIFF
--- a/lib/lunchbot/lunchbot_data.ex
+++ b/lib/lunchbot/lunchbot_data.ex
@@ -416,6 +416,43 @@ defmodule Lunchbot.LunchbotData do
     |> Enum.at(0)
   end
 
+  def list_most_recent_office_lunch_orders do
+    Repo.all(
+      from olo in OfficeLunchOrder,
+        order_by: [desc: olo.id],
+        limit: 10,
+        preload: [
+          office:
+            ^from(o in Office,
+              select: o.name
+            ),
+          menu:
+            ^from(m in Menu,
+              select: m.name
+            )
+        ]
+    )
+  end
+
+  def preload_new_olo(id) do
+    Repo.get!(
+      from(olo in OfficeLunchOrder,
+        where: olo.id == ^id,
+        preload: [
+          office:
+            ^from(o in Office,
+              select: o.name
+            ),
+          menu:
+            ^from(m in Menu,
+              select: m.name
+            )
+        ]
+      ),
+      id
+    )
+  end
+
   @doc """
   Gets a single office_lunch_order.
 

--- a/lib/lunchbot/lunchbot_data/menu.ex
+++ b/lib/lunchbot/lunchbot_data/menu.ex
@@ -6,6 +6,7 @@ defmodule Lunchbot.LunchbotData.Menu do
     field :name, :string
     field :office_id, :integer
     many_to_many :categories, Lunchbot.LunchbotData.Category, join_through: "menu_categories"
+    has_many :office_lunch_orders, Lunchbot.LunchbotData.OfficeLunchOrder
 
     timestamps()
   end

--- a/lib/lunchbot/lunchbot_data/office_lunch_order.ex
+++ b/lib/lunchbot/lunchbot_data/office_lunch_order.ex
@@ -4,7 +4,7 @@ defmodule Lunchbot.LunchbotData.OfficeLunchOrder do
 
   schema "office_lunch_orders" do
     field :day, :date
-    field :menu_id, :integer
+    belongs_to :menu, Lunchbot.LunchbotData.Menu
     belongs_to :office, Lunchbot.LunchbotData.Office
     has_many :orders, Lunchbot.LunchbotData.Order, foreign_key: :lunch_order_id
 

--- a/lib/lunchbot_web/live/select_menu_live.html.heex
+++ b/lib/lunchbot_web/live/select_menu_live.html.heex
@@ -23,3 +23,14 @@
         <%= submit "Submit" %>
     </div>
 </.form>
+
+<h2>Previous Office Lunch Orders</h2>
+    <div id="office_lunch_orders" phx-update="prepend">
+    <%= for olo <- @olos do %>
+        <div id={"#{olo.id}"}>
+            <div>
+            <%= olo.id %>, <%= olo.day %>, <%= olo.office %>, Menu: <%= olo.menu %>
+            </div>
+        </div>
+    <% end %>
+    </div>

--- a/lib/lunchbot_web/live/select_menu_live.html.heex
+++ b/lib/lunchbot_web/live/select_menu_live.html.heex
@@ -1,6 +1,6 @@
 <h1>Select a menu</h1>
 
-<.form let={f} for={@changeset} action={Routes.admin_select_menu_path(@conn, :create)}>
+<.form let={f} for={@changeset} url="#" phx-submit="save">
     <%= if @changeset.action do %>
         <div class="alert alert-danger">
             <p>Oops, something went wrong! Please check the errors below.</p>

--- a/lib/lunchbot_web/router.ex
+++ b/lib/lunchbot_web/router.ex
@@ -20,8 +20,6 @@ defmodule LunchbotWeb.Router do
   scope "/admin", LunchbotWeb.Admin, as: :admin do
     pipe_through [:browser, :require_admin_user]
 
-    get "/select_menu", SelectMenuController, :index
-    post "/select_menu", SelectMenuController, :create
     get "/export_orders", ExportOrdersController, :index
     get "/export_orders/export", ExportOrdersController, :export, as: :export
     resources "/users", UserController
@@ -37,6 +35,7 @@ defmodule LunchbotWeb.Router do
     resources "/order_item_options", OrderItemOptionsController
     resources "/options", OptionsController
     resources "/menu_categories", MenuCategoriesController
+    live "/select_menu", SelectMenuLive
   end
 
   scope "/", LunchbotWeb do


### PR DESCRIPTION
I switched select_menu to be a LiveView rather than a Phoenix controller to allow for an `office_lunch_order` to be created in the db and be listed on the webpage without a full page reload. (Trying to implement what I learned from a LiveView course I'm taking). When a new `office_lunch_order` is submitted, it is prepended to the list of recent menu selections as seen in the video below. 


https://user-images.githubusercontent.com/58053105/192611908-d8847bcd-3697-4806-b75a-5a0722425b2d.mov


~~Note: Whenever a new `office_lunch_order` is created and is shown being prepended to the list on the webpage, there is a GenServer error bug in the server. This is over an ecto association error. I know which part of my code is making this error so currently trying to find a way to fix it while still doing what I want it to do.~~ **Fixed**