### PR TITLE
Shared cart improvements

### DIFF
--- a/lib/lunchbot_web/controllers/shared_cart/shared_cart_controller.ex
+++ b/lib/lunchbot_web/controllers/shared_cart/shared_cart_controller.ex
@@ -19,7 +19,8 @@ defmodule LunchbotWeb.SharedCart.SharedCartController do
           {filter_lunch_orders_to_today_and_onwards,
            [
              orders:
-               {orders_sorted_query, [:menu, order_items: [:item, order_item_options: [:option]]]}
+               {orders_sorted_query,
+                [:user, :menu, order_items: [:item, order_item_options: [:option]]]}
            ]}
       )
 

--- a/lib/lunchbot_web/controllers/shared_cart/shared_cart_controller.ex
+++ b/lib/lunchbot_web/controllers/shared_cart/shared_cart_controller.ex
@@ -3,7 +3,14 @@ defmodule LunchbotWeb.SharedCart.SharedCartController do
 
   def get_lunch_order_for_office(office_id \\ 1, date \\ Date.utc_today()) do
     filter_lunch_orders_to_today_and_onwards =
-      from(o in Lunchbot.LunchbotData.OfficeLunchOrder, where: o.day >= ^date)
+      from(olo in Lunchbot.LunchbotData.OfficeLunchOrder,
+        where: olo.day >= ^date
+      )
+
+    orders_sorted_query =
+      from(o in Lunchbot.LunchbotData.Order,
+        order_by: [desc: o.updated_at]
+      )
 
     lunch_orders =
       Lunchbot.Repo.get_by(Lunchbot.LunchbotData.Office, id: office_id)
@@ -11,7 +18,8 @@ defmodule LunchbotWeb.SharedCart.SharedCartController do
         office_lunch_orders:
           {filter_lunch_orders_to_today_and_onwards,
            [
-             orders: [:menu, order_items: [:item, order_item_options: [:option]]]
+             orders:
+               {orders_sorted_query, [:menu, order_items: [:item, order_item_options: [:option]]]}
            ]}
       )
 

--- a/lib/lunchbot_web/live/components/order_component.ex
+++ b/lib/lunchbot_web/live/components/order_component.ex
@@ -11,7 +11,8 @@ defmodule LunchbotWeb.OrderComponent do
   def display_order(assigns) do
     ~H"""
     <div>
-      From <b><%= assigns.order.menu.name %></b> @ <em><%= assigns.order.inserted_at %></em>
+      <b><%= assigns.order.user.name %>'s Order </b> <br>
+      Placed @ <em><%= assigns.order.updated_at %></em>
       <ul>
         <%= for order_item <- assigns.order.order_items do %>
             <li><%= order_item.item.name %>


### PR DESCRIPTION
When a new order is created it is displayed at the top of the shared cart. The list of orders is in descending order (recent to oldest). User's name are now listed with their order.
<img width="256" alt="Screenshot 2022-11-10 at 9 30 21 AM" src="https://user-images.githubusercontent.com/58053105/201152876-299f8ea4-bcb2-44bd-b377-fb3b56ee2c19.png">
